### PR TITLE
use qtpy instead of PyQt5

### DIFF
--- a/napari_pyclesperanto_assistant/_gui/_AssistantGui.py
+++ b/napari_pyclesperanto_assistant/_gui/_AssistantGui.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
-from PyQt5 import QtGui
-from PyQt5.QtCore import QSize, Qt
-from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QAction, QPushButton, QFileDialog, QGridLayout
+from qtpy import QtGui
+from qtpy.QtCore import QSize, Qt
+from qtpy.QtGui import QPixmap
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QLabel, QAction, QPushButton, QFileDialog, QGridLayout
 
 from .._gui._LayerDialog import LayerDialog
 from .._scriptgenerators import JythonGenerator, PythonJupyterNotebookGenerator

--- a/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
+++ b/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
@@ -1,5 +1,5 @@
-from PyQt5 import QtGui
-from PyQt5.QtWidgets import QLabel
+from qtpy import QtGui
+from qtpy.QtWidgets import QLabel
 from magicgui._qt.widgets import QDataComboBox
 
 

--- a/napari_pyclesperanto_assistant/_operations/_operations.py
+++ b/napari_pyclesperanto_assistant/_operations/_operations.py
@@ -1,7 +1,7 @@
 
 # -----------------------------------------------------------------------------
 # The user interface of the _operations is build by magicgui
-from PyQt5.QtWidgets import QTableWidget, QTableWidgetItem
+from qtpy.QtWidgets import QTableWidget, QTableWidgetItem
 from magicgui import magicgui
 from napari.layers import Image
 import pyclesperanto_prototype as cle

--- a/napari_pyclesperanto_assistant/_scriptgenerators/_JythonGenerator.py
+++ b/napari_pyclesperanto_assistant/_scriptgenerators/_JythonGenerator.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QDoubleSpinBox, QSpinBox, QLineEdit
+from qtpy.QtWidgets import QDoubleSpinBox, QSpinBox, QLineEdit
 from magicgui._qt.widgets import QDataComboBox
 from napari.layers import Image, Labels
 import pyclesperanto_prototype as cle


### PR DESCRIPTION
This PR would change all of your `from PyQt5` imports to `from qtpy` ... [qtpy](https://github.com/spyder-ide/qtpy) is an abstraction layer around both PyQt5 and PySide2... so it doesn't matter what Qt backend your users are using.  In the napari bundle, for instance, we use pyside2 instead of PyQt5 (licensing reasons) ... so this package would likely not work there. 

(qtpy gets installed when you install napari or magicgui)