### PR TITLE
Compatibility with magicgui 0.2.0 [wip]

### DIFF
--- a/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
+++ b/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
@@ -1,18 +1,17 @@
 from PyQt5 import QtGui
-from PyQt5.QtWidgets import QLabel
-from magicgui._qt.widgets import QDataComboBox
-
+from PyQt5.QtWidgets import QLabel, QComboBox
+from magicgui.function_gui import FunctionGui
 
 class LayerDialog():
     """
     The LayerDialog contains a dock-widget that allows configuring parameters of all _operations.
     It uses events emitted by napari to toggle which dock widget is shown.
     """
-    def __init__(self, viewer, operation):
+    def __init__(self, viewer, operation: FunctionGui):
         self.viewer = viewer
 
-        self.operation = operation
-        self.operation.self = self # arrrrg
+        self.filter_gui = operation
+        self.filter_gui.self = self # arrrrg
 
         former_active_layer = self.viewer.active_layer
         try:
@@ -22,12 +21,12 @@ class LayerDialog():
         except KeyError:
             pass
 
-        self.operation.initial_call = True
-        self.operation(self.viewer.active_layer)
+        self.filter_gui.initial_call = True
+        self.filter_gui(self.viewer.active_layer)
         self.layer = self.viewer.active_layer
         if(self.layer is None):
             import time
-            self.operation(self.viewer.active_layer)
+            self.filter_gui(self.viewer.active_layer)
             time.sleep(0.1) # dirty workaround: wait until napari has set its active_layer
             self.layer = self.viewer.active_layer
 
@@ -37,28 +36,24 @@ class LayerDialog():
         self.layer.events.select.connect(self._selected)
         self.layer.events.deselect.connect(self._deselected)
 
-        self.filter_gui = self.operation.Gui()
         self.dock_widget = viewer.window.add_dock_widget(self.filter_gui, area='right')
         self.dock_widget.setMaximumWidth(300)
-        try:
-            if self.filter_gui.get_widget('input1') is not None:
-                self.filter_gui.set_widget('input1', former_active_layer)
-        except AttributeError:
-            pass
+        if hasattr(self.filter_gui, 'input1'):
+            print("setting former active")
+            self.filter_gui.input1.value = former_active_layer
 
-        for i in reversed(range(self.filter_gui.layout().count())):
-            widget = self.filter_gui.layout().itemAt(i).widget()
-            widget.setFont(QtGui.QFont('Arial', 12))
-            if isinstance(widget, QDataComboBox):
-                widget.setMaximumWidth(200)
-            if isinstance(widget, QLabel):
-                widget.setMaximumWidth(100)
+        for widget in self.filter_gui:
+            widget.native.setFont(QtGui.QFont('Arial', 12))
+            if isinstance(widget.native, QComboBox):
+                widget.native.setMaximumWidth(200)
+            if isinstance(widget.native, QLabel):
+                widget.native.setMaximumWidth(100)
 
     def _updated(self, event):
         self.refresh_all_followers()
 
     def _selected(self, event):
-        self.operation.self = self    # sigh
+        self.filter_gui.self = self    # sigh
         self.dock_widget = self.viewer.window.add_dock_widget(self.filter_gui, area='right')
 
     def _deselected(self, event):
@@ -73,10 +68,11 @@ class LayerDialog():
         """
         Refresh/recompute the current layer
         """
-        former = self.operation.self
-        self.operation.self = self    # sigh
+        former = self.filter_gui.self
+        self.filter_gui.self = self    # sigh
+        print("calling op")
         self.filter_gui()
-        self.operation.self = former
+        self.filter_gui.self = former
 
     def refresh_all_followers(self):
         """
@@ -84,14 +80,14 @@ class LayerDialog():
         Then, refresh those layers.
         """
         for layer in self.viewer.layers:
-            if layer != self.layer:
-                try:
-                    if layer.metadata['dialog'].filter_gui.get_widget('input1').currentData() == self.layer:
-                        print(self.layer.name + " refreshes " + layer.name)
-                        layer.metadata['dialog'].refresh()
-                    if layer.metadata['dialog'].filter_gui.get_widget('input2').currentData() == self.layer:
-                        layer.metadata['dialog'].refresh()
-                except AttributeError:
-                    pass
-                except KeyError:
-                    pass
+            if layer == self.layer:
+                continue
+            dialog = layer.metadata.get('dialog')
+            if not dialog:
+                continue
+            gui = dialog.filter_gui
+            if hasattr(gui, 'input1') and gui.input1.value == self.layer:
+                print(self.layer.name + " refreshes " + layer.name)
+                dialog.refresh()
+            if hasattr(gui, 'input2') and gui.input2.value == self.layer:
+                dialog.refresh()

--- a/napari_pyclesperanto_assistant/_operations/_operations.py
+++ b/napari_pyclesperanto_assistant/_operations/_operations.py
@@ -6,13 +6,15 @@ from magicgui import magicgui
 from napari.layers import Image
 import pyclesperanto_prototype as cle
 
+plus_minus_1k = {'min': -1000, 'max': 1000}
+
 @magicgui(
     auto_call=True,
     layout='vertical',
     operation_name={'choices':cle.operations(must_have_categories=['filter', 'denoise','in assistant'], must_not_have_categories=['combine']).keys()},
-    x={'minimum': -1000, 'maximum': 1000},
-    y={'minimum': -1000, 'maximum': 1000},
-    z={'minimum': -1000, 'maximum': 1000},
+    x=plus_minus_1k,
+    y=plus_minus_1k,
+    z=plus_minus_1k,
 )
 def denoise(input1: Image, operation_name: str = cle.gaussian_blur.__name__, x: float = 1, y: float = 1, z: float = 0):
     if input1:
@@ -40,9 +42,9 @@ def denoise(input1: Image, operation_name: str = cle.gaussian_blur.__name__, x: 
     auto_call=True,
     layout='vertical',
     operation_name={'choices':cle.operations(must_have_categories=['filter', 'background removal','in assistant'], must_not_have_categories=['combine']).keys()},
-    x={'minimum': -1000, 'maximum': 1000},
-    y={'minimum': -1000, 'maximum': 1000},
-    z={'minimum': -1000, 'maximum': 1000},
+    x=plus_minus_1k,
+    y=plus_minus_1k,
+    z=plus_minus_1k,
 )
 def background_removal(input1: Image, operation_name: str = cle.top_hat_box.__name__, x: float = 10, y: float = 10, z: float = 0):
     if input1:
@@ -70,9 +72,9 @@ def background_removal(input1: Image, operation_name: str = cle.top_hat_box.__na
     auto_call=True,
     layout='vertical',
     operation_name={'choices':cle.operations(must_have_categories=['filter', 'in assistant'], must_not_have_categories=['combine', 'denoise', 'background removal']).keys()},
-    x={'minimum': -1000, 'maximum': 1000},
-    y={'minimum': -1000, 'maximum': 1000},
-    z={'minimum': -1000, 'maximum': 1000},
+    x=plus_minus_1k,
+    y=plus_minus_1k,
+    z=plus_minus_1k,
 )
 def filter(input1: Image, operation_name: str = cle.gamma_correction.__name__, x: float = 1, y: float = 1, z: float = 0):
     if input1:
@@ -101,9 +103,9 @@ def filter(input1: Image, operation_name: str = cle.gamma_correction.__name__, x
     auto_call=True,
     layout='vertical',
     operation_name={'choices':cle.operations(must_have_categories=['binarize', 'in assistant'], must_not_have_categories=['combine']).keys()},
-    radius_x={'minimum':-1000, 'maximum':1000},
-    radius_y={'minimum':-1000, 'maximum':1000},
-    radius_z={'minimum':-1000, 'maximum':1000}
+    radius_x=plus_minus_1k,
+    radius_y=plus_minus_1k,
+    radius_z=plus_minus_1k
 )
 def binarize(input1: Image, operation_name : str = cle.threshold_otsu.__name__, radius_x : int = 1, radius_y : int = 1, radius_z : int = 0):
     if input1 is not None:
@@ -184,8 +186,8 @@ def label(input1: Image, operation_name: str = cle.connected_components_labeling
     auto_call=True,
     layout='vertical',
     operation_name={'choices':cle.operations(must_have_categories=['label processing', 'in assistant']).keys()},
-    min = {'minimum': -1000, 'maximum': 1000},
-    max = {'minimum': -1000, 'maximum': 1000}
+    min = plus_minus_1k,
+    max = plus_minus_1k
 )
 def label_processing(input1: Image, operation_name: str = cle.exclude_labels_on_edges.__name__, min: float=0, max:float=100):
     if input1 is not None:
@@ -210,7 +212,7 @@ def label_processing(input1: Image, operation_name: str = cle.exclude_labels_on_
     auto_call=True,
     layout='vertical',
     operation_name={'choices':cle.operations(must_have_categories=['label measurement', 'mesh', 'in assistant'], must_not_have_categories=["combine"]).keys()},
-    n = {'minimum': 0, 'maximum': 1000}
+    n = {'min': 0, 'max': 1000}
 )
 def mesh(input1: Image, operation_name : str = cle.draw_mesh_between_touching_labels.__name__, n : float = 1):
     if input1 is not None:
@@ -240,7 +242,7 @@ def mesh(input1: Image, operation_name : str = cle.draw_mesh_between_touching_la
     auto_call=True,
     layout='vertical',
     operation_name={'choices':cle.operations(must_have_categories=['label measurement', 'map', 'in assistant'], must_not_have_categories=["combine"]).keys()},
-    n = {'minimum': 0, 'maximum': 1000}
+    n = {'min': 0, 'max': 1000}
 )
 def map(input1: Image, operation_name: str = cle.label_pixel_count_map.__name__, n : float = 1):
     if input1 is not None:

--- a/napari_pyclesperanto_assistant/_scriptgenerators/_JythonGenerator.py
+++ b/napari_pyclesperanto_assistant/_scriptgenerators/_JythonGenerator.py
@@ -1,5 +1,4 @@
-from PyQt5.QtWidgets import QDoubleSpinBox, QSpinBox, QLineEdit
-from magicgui._qt.widgets import QDataComboBox
+from PyQt5.QtWidgets import QDoubleSpinBox, QSpinBox, QLineEdit, QComboBox
 from napari.layers import Image, Labels
 import pyclesperanto_prototype as cle
 
@@ -38,12 +37,14 @@ class JythonGenerator(ScriptGenerator):
     def _execute(self, layer, layer_number):
         command = ""
         try:
-            method = cle.operation(layer.metadata['dialog'].filter_gui.get_widget("operation_name").currentData())
+            method = cle.operation(layer.metadata['dialog'].filter_gui.operation_name.value)
             parameter_names = method.fullargspec.args
             method_name = "cle." + method.__name__
             method_name = method_name.replace("please_select", "copy")
         except AttributeError:
-            method = layer.metadata['dialog'].filter_gui.func
+            method = layer.metadata['dialog'].filter_gui._function
+
+            # let's chat about this, probably a better way
             import inspect
             parameter_names = inspect.getfullargspec(method).args
             method_name = method.__name__
@@ -55,21 +56,22 @@ class JythonGenerator(ScriptGenerator):
         first_image_parameter = None
 
         put_comma = False
-        for i, parameter_name in enumerate(layer.metadata['dialog'].filter_gui.param_names):
+        for i, parameter_name in enumerate([x.name for x in layer.metadata['dialog'].filter_gui]):
             if (i < len(parameter_names)):
                 comma = ""
                 if put_comma:
                     comma = ", "
                 put_comma = True
 
-                widget = layer.metadata['dialog'].filter_gui.get_widget(parameter_name)
+                widget = layer.metadata['dialog'].filter_gui.parameter_name
 
-                if isinstance(widget, QDoubleSpinBox) or isinstance(widget, QSpinBox):
-                    value = widget.value()
-                elif isinstance(widget, QDataComboBox):
-                    value = widget.currentData()
-                elif isinstance(widget, QLineEdit):
-                    value = widget.text()
+                # better way
+                if isinstance(widget.native, QDoubleSpinBox) or isinstance(widget, QSpinBox):
+                    value = widget.native.value()
+                elif isinstance(widget.native, QComboBox):
+                    value = widget.native.currentData()
+                elif isinstance(widget.native, QLineEdit):
+                    value = widget.native.text()
                 else:
                     value = None
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/clesperanto/napari_pyclesperanto_assistant",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=["numpy", "pyopencl", "toolz", "scikit-image", "napari==0.4.2", "napari_plugin_engine", "pyclesperanto_prototype==0.6.0", "magicgui==0.1.6", "numpy==1.19.3", "pyperclip"],
+    install_requires=["numpy", "pyopencl", "toolz", "scikit-image", "napari==0.4.2", "napari_plugin_engine", "pyclesperanto_prototype==0.6.0", "magicgui>=0.2.1", "numpy==1.19.3", "pyperclip"],
     python_requires='>=3.6',
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
These are the main things that need to change for the new magicgui and napari.  I may have missed a thing here or there, but it seems to be mostly working for me.  Let's talk about Jython export separately, we can definitely improve that.

The main changes that affect you here:
- min/max instead of minimum/maximum (though, after https://github.com/napari/magicgui/pull/82, even that would be ok with a warning)
- the `function_gui` (or sometimes "`operation`") object itself is now a `magicgui.widgets.Widget`, and rather than directly inheriting from `QWidget`, it now comprises a `QWidget` at `function_gui.native` ("native", since we now can support multiple backends in addition to Qt).  So all of the direct places where you used the Qt API need to be applied to `function_gui.native`
- `function_gui` behaves like a list, so rather than iterating through `filter_gui.layout()` you can just iterate `function_gui` directly, and it will yield the subwidgets in the gui.
- I'm impressed you found and used `get_widget`, `set_widget` :) but they were terrible public APIs.  Now, rather than `function_gui.set_widget('param_name', val)`, you do `function_gui.param_name.value = val`