### PR TITLE
Refactor self and magicguis

### DIFF
--- a/napari_pyclesperanto_assistant/_gui/_Assistant.py
+++ b/napari_pyclesperanto_assistant/_gui/_Assistant.py
@@ -34,22 +34,22 @@ class Assistant(QWidget):
         for i in reversed(range(self.layout.count())):
             self.layout.itemAt(i).widget().setParent(None)
 
-        from .._operations._operations import SelfAwareFunctionFactory, denoise, background_removal, filter, binarize, combine, label, label_processing, map, mesh, measure, label_measurements, transform, projection
+        from .._operations._operations import StatefulFunctionFactory, denoise, background_removal, filter, binarize, combine, label, label_processing, map, mesh, measure, label_measurements, transform, projection
 
-        self.add_button("Noise removal", SelfAwareFunctionFactory(denoise), 1, 0)
-        self.add_button("Background removal", SelfAwareFunctionFactory(background_removal), 1, 1)
-        self.add_button("Filter", SelfAwareFunctionFactory(filter), 1, 2)
-        self.add_button("Combine", SelfAwareFunctionFactory(combine), 2, 0)
-        self.add_button("Transform", SelfAwareFunctionFactory(transform), 2, 1)
-        self.add_button("Projection", SelfAwareFunctionFactory(projection), 2, 2)
+        self.add_button("Noise removal", StatefulFunctionFactory(denoise), 1, 0)
+        self.add_button("Background removal", StatefulFunctionFactory(background_removal), 1, 1)
+        self.add_button("Filter", StatefulFunctionFactory(filter), 1, 2)
+        self.add_button("Combine", StatefulFunctionFactory(combine), 2, 0)
+        self.add_button("Transform", StatefulFunctionFactory(transform), 2, 1)
+        self.add_button("Projection", StatefulFunctionFactory(projection), 2, 2)
 
-        self.add_button("Binarize", SelfAwareFunctionFactory(binarize), 3, 0)
-        self.add_button("Label", SelfAwareFunctionFactory(label), 3, 1)
-        self.add_button("Label processing", SelfAwareFunctionFactory(label_processing), 3, 2)
-        self.add_button("Label measurements", SelfAwareFunctionFactory(label_measurements), 5, 0)
-        self.add_button("Map", SelfAwareFunctionFactory(map), 4, 0)
-        self.add_button("Mesh", SelfAwareFunctionFactory(mesh), 4, 1)
-        self.add_button("Measure", SelfAwareFunctionFactory(measure), 5, 1)
+        self.add_button("Binarize", StatefulFunctionFactory(binarize), 3, 0)
+        self.add_button("Label", StatefulFunctionFactory(label), 3, 1)
+        self.add_button("Label processing", StatefulFunctionFactory(label_processing), 3, 2)
+        self.add_button("Label measurements", StatefulFunctionFactory(label_measurements), 5, 0)
+        self.add_button("Map", StatefulFunctionFactory(map), 4, 0)
+        self.add_button("Mesh", StatefulFunctionFactory(mesh), 4, 1)
+        self.add_button("Measure", StatefulFunctionFactory(measure), 5, 1)
 
         # spacer
         label = QLabel("", self)

--- a/napari_pyclesperanto_assistant/_gui/_Assistant.py
+++ b/napari_pyclesperanto_assistant/_gui/_Assistant.py
@@ -34,22 +34,24 @@ class Assistant(QWidget):
         for i in reversed(range(self.layout.count())):
             self.layout.itemAt(i).widget().setParent(None)
 
-        from .._operations._operations import StatefulFunctionFactory, denoise, background_removal, filter, binarize, combine, label, label_processing, map, mesh, measure, label_measurements, transform, projection
+        from .._operations._operations import StatefulFunctionFactory, magic_denoise, magic_background_removal, \
+            magic_filter, magic_binarize, magic_combine, magic_label, magic_label_processing, magic_map, \
+            magic_mesh, magic_measure, magic_label_measurements, magic_transform, magic_projection
 
-        self.add_button("Noise removal", StatefulFunctionFactory(denoise), 1, 0)
-        self.add_button("Background removal", StatefulFunctionFactory(background_removal), 1, 1)
-        self.add_button("Filter", StatefulFunctionFactory(filter), 1, 2)
-        self.add_button("Combine", StatefulFunctionFactory(combine), 2, 0)
-        self.add_button("Transform", StatefulFunctionFactory(transform), 2, 1)
-        self.add_button("Projection", StatefulFunctionFactory(projection), 2, 2)
+        self.add_button("Noise removal", StatefulFunctionFactory(magic_denoise), 1, 0)
+        self.add_button("Background removal", StatefulFunctionFactory(magic_background_removal), 1, 1)
+        self.add_button("Filter", StatefulFunctionFactory(magic_filter), 1, 2)
+        self.add_button("Combine", StatefulFunctionFactory(magic_combine), 2, 0)
+        self.add_button("Transform", StatefulFunctionFactory(magic_transform), 2, 1)
+        self.add_button("Projection", StatefulFunctionFactory(magic_projection), 2, 2)
 
-        self.add_button("Binarize", StatefulFunctionFactory(binarize), 3, 0)
-        self.add_button("Label", StatefulFunctionFactory(label), 3, 1)
-        self.add_button("Label processing", StatefulFunctionFactory(label_processing), 3, 2)
-        self.add_button("Label measurements", StatefulFunctionFactory(label_measurements), 5, 0)
-        self.add_button("Map", StatefulFunctionFactory(map), 4, 0)
-        self.add_button("Mesh", StatefulFunctionFactory(mesh), 4, 1)
-        self.add_button("Measure", StatefulFunctionFactory(measure), 5, 1)
+        self.add_button("Binarize", StatefulFunctionFactory(magic_binarize), 3, 0)
+        self.add_button("Label", StatefulFunctionFactory(magic_label), 3, 1)
+        self.add_button("Label processing", StatefulFunctionFactory(magic_label_processing), 3, 2)
+        self.add_button("Label measurements", StatefulFunctionFactory(magic_label_measurements), 5, 0)
+        self.add_button("Map", StatefulFunctionFactory(magic_map), 4, 0)
+        self.add_button("Mesh", StatefulFunctionFactory(magic_mesh), 4, 1)
+        self.add_button("Measure", StatefulFunctionFactory(magic_measure), 5, 1)
 
         # spacer
         label = QLabel("", self)

--- a/napari_pyclesperanto_assistant/_gui/_Assistant.py
+++ b/napari_pyclesperanto_assistant/_gui/_Assistant.py
@@ -34,22 +34,22 @@ class Assistant(QWidget):
         for i in reversed(range(self.layout.count())):
             self.layout.itemAt(i).widget().setParent(None)
 
-        from .._operations._operations import SelfAwareFunction, denoise, background_removal, filter, binarize, combine, label, label_processing, map, mesh, measure, label_measurements, transform, projection
+        from .._operations._operations import SelfAwareFunctionFactory, denoise, background_removal, filter, binarize, combine, label, label_processing, map, mesh, measure, label_measurements, transform, projection
 
-        self.add_button("Noise removal", SelfAwareFunction(denoise), 1, 0)
-        self.add_button("Background removal", SelfAwareFunction(background_removal), 1, 1)
-        self.add_button("Filter", SelfAwareFunction(filter), 1, 2)
-        self.add_button("Combine", SelfAwareFunction(combine), 2, 0)
-        self.add_button("Transform", SelfAwareFunction(transform), 2, 1)
-        self.add_button("Projection", SelfAwareFunction(projection), 2, 2)
+        self.add_button("Noise removal", SelfAwareFunctionFactory(denoise), 1, 0)
+        self.add_button("Background removal", SelfAwareFunctionFactory(background_removal), 1, 1)
+        self.add_button("Filter", SelfAwareFunctionFactory(filter), 1, 2)
+        self.add_button("Combine", SelfAwareFunctionFactory(combine), 2, 0)
+        self.add_button("Transform", SelfAwareFunctionFactory(transform), 2, 1)
+        self.add_button("Projection", SelfAwareFunctionFactory(projection), 2, 2)
 
-        self.add_button("Binarize", SelfAwareFunction(binarize), 3, 0)
-        self.add_button("Label", SelfAwareFunction(label), 3, 1)
-        self.add_button("Label processing", SelfAwareFunction(label_processing), 3, 2)
-        self.add_button("Label measurements", SelfAwareFunction(label_measurements), 5, 0)
-        self.add_button("Map", SelfAwareFunction(map), 4, 0)
-        self.add_button("Mesh", SelfAwareFunction(mesh), 4, 1)
-        self.add_button("Measure", SelfAwareFunction(measure), 5, 1)
+        self.add_button("Binarize", SelfAwareFunctionFactory(binarize), 3, 0)
+        self.add_button("Label", SelfAwareFunctionFactory(label), 3, 1)
+        self.add_button("Label processing", SelfAwareFunctionFactory(label_processing), 3, 2)
+        self.add_button("Label measurements", SelfAwareFunctionFactory(label_measurements), 5, 0)
+        self.add_button("Map", SelfAwareFunctionFactory(map), 4, 0)
+        self.add_button("Mesh", SelfAwareFunctionFactory(mesh), 4, 1)
+        self.add_button("Measure", SelfAwareFunctionFactory(measure), 5, 1)
 
         # spacer
         label = QLabel("", self)

--- a/napari_pyclesperanto_assistant/_gui/_Assistant.py
+++ b/napari_pyclesperanto_assistant/_gui/_Assistant.py
@@ -34,22 +34,22 @@ class Assistant(QWidget):
         for i in reversed(range(self.layout.count())):
             self.layout.itemAt(i).widget().setParent(None)
 
-        from .._operations._operations import denoise, background_removal, filter, binarize, combine, label, label_processing, map, mesh, measure, label_measurements, transform, projection
+        from .._operations._operations import SelfAwareFunction, denoise, background_removal, filter, binarize, combine, label, label_processing, map, mesh, measure, label_measurements, transform, projection
 
-        self.add_button("Noise removal", denoise, 1, 0)
-        self.add_button("Background removal", background_removal, 1, 1)
-        self.add_button("Filter", filter, 1, 2)
-        self.add_button("Combine", combine, 2, 0)
-        self.add_button("Transform", transform, 2, 1)
-        self.add_button("Projection", projection, 2, 2)
+        self.add_button("Noise removal", SelfAwareFunction(denoise), 1, 0)
+        self.add_button("Background removal", SelfAwareFunction(background_removal), 1, 1)
+        self.add_button("Filter", SelfAwareFunction(filter), 1, 2)
+        self.add_button("Combine", SelfAwareFunction(combine), 2, 0)
+        self.add_button("Transform", SelfAwareFunction(transform), 2, 1)
+        self.add_button("Projection", SelfAwareFunction(projection), 2, 2)
 
-        self.add_button("Binarize", binarize, 3, 0)
-        self.add_button("Label", label, 3, 1)
-        self.add_button("Label processing", label_processing, 3, 2)
-        self.add_button("Label measurements", label_measurements, 5, 0)
-        self.add_button("Map", map, 4, 0)
-        self.add_button("Mesh", mesh, 4, 1)
-        self.add_button("Measure", measure, 5, 1)
+        self.add_button("Binarize", SelfAwareFunction(binarize), 3, 0)
+        self.add_button("Label", SelfAwareFunction(label), 3, 1)
+        self.add_button("Label processing", SelfAwareFunction(label_processing), 3, 2)
+        self.add_button("Label measurements", SelfAwareFunction(label_measurements), 5, 0)
+        self.add_button("Map", SelfAwareFunction(map), 4, 0)
+        self.add_button("Mesh", SelfAwareFunction(mesh), 4, 1)
+        self.add_button("Measure", SelfAwareFunction(measure), 5, 1)
 
         # spacer
         label = QLabel("", self)
@@ -86,7 +86,7 @@ class Assistant(QWidget):
 
         self.viewer.layers.events.removed.connect(_on_removed)
 
-    def add_button(self, title : str, handler : callable, x : int = None, y : int = None):
+    def add_button(self, title : str, handler, x : int = None, y : int = None):
         # text
         btn = QPushButton('', self)
         btn.setFont(self.font)

--- a/napari_pyclesperanto_assistant/_gui/_Assistant.py
+++ b/napari_pyclesperanto_assistant/_gui/_Assistant.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 
 from qtpy import QtGui
@@ -125,6 +126,9 @@ class Assistant(QWidget):
             self.layout.addWidget(btn, x, y)
 
     def _activate(self, magicgui):
+        if self.viewer.active_layer is None:
+            warnings.warn("Select a layer first!")
+            return
         LayerDialog(self.viewer, magicgui)
 
     def _export_jython_code(self):

--- a/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
+++ b/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
@@ -3,12 +3,12 @@ class LayerDialog():
     The LayerDialog contains a dock-widget that allows configuring parameters of all _operations.
     It uses events emitted by napari to toggle which dock widget is shown.
     """
-    def __init__(self, viewer, self_aware_function_factory):
+    def __init__(self, viewer, stateful_function_factory):
         self.viewer = viewer
-        self.self_aware_function = self_aware_function_factory.get()
-        self.self_aware_function.viewer = viewer
+        self.stateful_function = stateful_function_factory.get()
+        self.stateful_function.viewer = viewer
 
-        self.filter_gui = self.self_aware_function.get()
+        self.filter_gui = self.stateful_function.get()
         self.filter_gui.native.setParent(viewer.window.qt_viewer)
 
         former_active_layer = self.viewer.active_layer
@@ -21,8 +21,8 @@ class LayerDialog():
 
         self.filter_gui(self.viewer.active_layer)
         self.layer = self.viewer.active_layer
-        if self.self_aware_function is not None:
-            self.self_aware_function.layer = self.layer
+        if self.stateful_function is not None:
+            self.stateful_function.layer = self.layer
 
         if(self.layer is None):
             import time

--- a/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
+++ b/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
@@ -11,9 +11,6 @@ class LayerDialog():
         self.filter_gui = self.stateful_function.get()
         self.filter_gui.native.setParent(viewer.window.qt_viewer)
 
-        import warnings
-        warnings.warn("are we leaking this?" + str(self.filter_gui.native))
-
         former_active_layer = self.viewer.active_layer
         try:
             former_active_layer.metadata['dialog']._deselected(None)

--- a/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
+++ b/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
@@ -5,9 +5,13 @@ class LayerDialog():
     """
     def __init__(self, viewer, operation):
         self.viewer = viewer
+        self.op_object = operation.get()
+        self.op_object.viewer = viewer
+
+        operation = self.op_object.get()
+        operation.native.setParent(viewer.window.qt_viewer)
 
         self.filter_gui = operation
-        self.filter_gui.self = self # arrrrg
 
         former_active_layer = self.viewer.active_layer
         try:
@@ -19,6 +23,9 @@ class LayerDialog():
 
         self.filter_gui(self.viewer.active_layer)
         self.layer = self.viewer.active_layer
+        if self.op_object is not None:
+            self.op_object.layer = self.layer
+
         if(self.layer is None):
             import time
             self.filter_gui(self.viewer.active_layer)
@@ -32,6 +39,7 @@ class LayerDialog():
         self.layer.events.deselect.connect(self._deselected)
 
         self.dock_widget = viewer.window.add_dock_widget(self.filter_gui, area='right')
+        
         #self.dock_widget.setMaximumWidth(300)
         if hasattr(self.filter_gui, 'input1'):
             print("setting former active")
@@ -48,7 +56,6 @@ class LayerDialog():
         self.refresh_all_followers()
 
     def _selected(self, event):
-        self.filter_gui.self = self    # sigh
         if hasattr(self, 'dock_widget'):
             self.dock_widget.show()
         else:
@@ -70,11 +77,9 @@ class LayerDialog():
         """
         Refresh/recompute the current layer
         """
-        former = self.filter_gui.self
-        self.filter_gui.self = self    # sigh
+
         print("calling op")
         self.filter_gui()
-        self.filter_gui.self = former
 
     def refresh_all_followers(self):
         """

--- a/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
+++ b/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
@@ -39,7 +39,7 @@ class LayerDialog():
         self.layer.events.deselect.connect(self._deselected)
 
         self.dock_widget = viewer.window.add_dock_widget(self.filter_gui, area='right')
-        
+
         #self.dock_widget.setMaximumWidth(300)
         if hasattr(self.filter_gui, 'input1'):
             print("setting former active")

--- a/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
+++ b/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
@@ -3,15 +3,13 @@ class LayerDialog():
     The LayerDialog contains a dock-widget that allows configuring parameters of all _operations.
     It uses events emitted by napari to toggle which dock widget is shown.
     """
-    def __init__(self, viewer, operation):
+    def __init__(self, viewer, self_aware_function_factory):
         self.viewer = viewer
-        self.op_object = operation.get()
-        self.op_object.viewer = viewer
+        self.self_aware_function = self_aware_function_factory.get()
+        self.self_aware_function.viewer = viewer
 
-        operation = self.op_object.get()
-        operation.native.setParent(viewer.window.qt_viewer)
-
-        self.filter_gui = operation
+        self.filter_gui = self.self_aware_function.get()
+        self.filter_gui.native.setParent(viewer.window.qt_viewer)
 
         former_active_layer = self.viewer.active_layer
         try:
@@ -23,8 +21,8 @@ class LayerDialog():
 
         self.filter_gui(self.viewer.active_layer)
         self.layer = self.viewer.active_layer
-        if self.op_object is not None:
-            self.op_object.layer = self.layer
+        if self.self_aware_function is not None:
+            self.self_aware_function.layer = self.layer
 
         if(self.layer is None):
             import time

--- a/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
+++ b/napari_pyclesperanto_assistant/_gui/_LayerDialog.py
@@ -11,6 +11,9 @@ class LayerDialog():
         self.filter_gui = self.stateful_function.get()
         self.filter_gui.native.setParent(viewer.window.qt_viewer)
 
+        import warnings
+        warnings.warn("are we leaking this?" + str(self.filter_gui.native))
+
         former_active_layer = self.viewer.active_layer
         try:
             former_active_layer.metadata['dialog']._deselected(None)

--- a/napari_pyclesperanto_assistant/_operations/_operations.py
+++ b/napari_pyclesperanto_assistant/_operations/_operations.py
@@ -4,7 +4,7 @@
 from typing import Union
 
 from qtpy.QtWidgets import QTableWidget, QTableWidgetItem
-from magicgui import magicgui
+from magicgui import magicgui, magic_factory
 from napari.layers import Image, Labels, Layer
 import pyclesperanto_prototype as cle
 
@@ -44,39 +44,57 @@ def label_parameters(operation, parameters):
         parameters[i].label = ""
         parameters[i].text = ""
 
-@magicgui(
-    auto_call=True,
-    layout='vertical',
-    input1={'label':'Image'},
-    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['filter', 'denoise','in assistant'], must_not_have_categories=['combine']).keys()},
-    x=plus_minus_1k,
-    y=plus_minus_1k,
-    z=plus_minus_1k,
-)
-def denoise(input1: Image, operation_name: str = cle.gaussian_blur.__name__, x: float = 1, y: float = 1, z: float = 0):
+class SelfAwareFunctionInstance():
+    def __init__(self, factory):
+        self.gui = factory()
+        self.gui.myself.bind(self)
+
+
+    def get(self):
+        return self.gui
+
+class SelfAwareFunction():
+    def __init__(self, factory):
+        self.factory = factory
+
+    def get(self):
+        return SelfAwareFunctionInstance(self.factory)
+
+@magic_factory(auto_call=True,
+                layout='vertical',
+                input1={'label':'Image'},
+                operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['filter', 'denoise','in assistant'], must_not_have_categories=['combine']).keys()},
+                x=plus_minus_1k,
+                y=plus_minus_1k,
+                z=plus_minus_1k)
+def denoise(input1: Image, operation_name: str = cle.gaussian_blur.__name__, x: float = 1, y: float = 1,
+            z: float = 0, myself=None):
     if input1:
         # execute operation
         cle_input = cle.push(input1.data)
         output = cle.create_like(cle_input)
         operation = cle.operation(operation_name)
         # update GUI
-        label_parameters(operation, [denoise.x, denoise.y, denoise.z])
+        label_parameters(operation, [myself.gui.x, myself.gui.y, myself.gui.z])
         _call_operation_ignoring_to_many_arguments(operation, [cle_input, output, x, y, z])
         max_intensity = cle.maximum_of_all_pixels(output)
         if max_intensity == 0:
-            max_intensity = 1 # prevent division by zero in vispy
+            max_intensity = 1  # prevent division by zero in vispy
         output = cle.pull(output)
 
         # show result in napari
-        if not hasattr(denoise.self, 'layer'):
-            denoise.self.viewer.add_image(output, colormap=input1.colormap, translate=input1.translate)
+        if not hasattr(myself, 'layer'):
+            myself.viewer.add_image(output, colormap=input1.colormap, translate=input1.translate)
         else:
-            denoise.self.layer.data = output
-            denoise.self.layer.name = "Result of " + operation.__name__
-            denoise.self.layer.contrast_limits=(0, max_intensity)
-            denoise.self.layer.translate = input1.translate
+            myself.layer.data = output
+            myself.layer.name = "Result of " + operation.__name__
+            myself.layer.contrast_limits = (0, max_intensity)
+            myself.layer.translate = input1.translate
 
-@magicgui(
+
+
+
+@magic_factory(
     auto_call=True,
     layout='vertical',
     input1={'label':'Image'},
@@ -85,14 +103,14 @@ def denoise(input1: Image, operation_name: str = cle.gaussian_blur.__name__, x: 
     y=plus_minus_1k,
     z=plus_minus_1k,
 )
-def background_removal(input1: Image, operation_name: str = cle.top_hat_box.__name__, x: float = 10, y: float = 10, z: float = 0):
+def background_removal(input1: Image, operation_name: str = cle.top_hat_box.__name__, x: float = 10, y: float = 10, z: float = 0, myself = None):
     if input1:
         # execute operation
         cle_input = cle.push(input1.data)
         output = cle.create_like(cle_input)
         operation = cle.operation(operation_name)
         # update GUI
-        label_parameters(operation, [background_removal.x, background_removal.y, background_removal.z])
+        label_parameters(operation, [myself.gui.x, background_removal.y, background_removal.z])
         _call_operation_ignoring_to_many_arguments(operation, [cle_input, output, x, y, z])
         max_intensity = cle.maximum_of_all_pixels(output)
         if max_intensity == 0:
@@ -100,15 +118,15 @@ def background_removal(input1: Image, operation_name: str = cle.top_hat_box.__na
         output = cle.pull(output)
 
         # show result in napari
-        if not hasattr(background_removal.self, 'layer'):
-            background_removal.self.viewer.add_image(output, colormap=input1.colormap, translate=input1.translate)
+        if not hasattr(myself, 'layer'):
+            myself.viewer.add_image(output, colormap=input1.colormap, translate=input1.translate)
         else:
-            background_removal.self.layer.data = output
-            background_removal.self.layer.name = "Result of " + operation.__name__
-            background_removal.self.layer.contrast_limits=(0, max_intensity)
-            background_removal.self.layer.translate = input1.translate
+            myself.layer.data = output
+            myself.layer.name = "Result of " + operation.__name__
+            myself.layer.contrast_limits=(0, max_intensity)
+            myself.layer.translate = input1.translate
 
-@magicgui(
+@magic_factory(
     auto_call=True,
     layout='vertical',
     input1={'label':'Image'},
@@ -117,14 +135,14 @@ def background_removal(input1: Image, operation_name: str = cle.top_hat_box.__na
     y=plus_minus_1k,
     z=plus_minus_1k,
 )
-def filter(input1: Image, operation_name: str = cle.gamma_correction.__name__, x: float = 1, y: float = 1, z: float = 0):
+def filter(input1: Image, operation_name: str = cle.gamma_correction.__name__, x: float = 1, y: float = 1, z: float = 0, myself = None):
     if input1:
         # execute operation
         cle_input = cle.push(input1.data)
         output = cle.create_like(cle_input)
         operation = cle.operation(operation_name)
         # update GUI
-        label_parameters(operation, [filter.x, filter.y, filter.z])
+        label_parameters(operation, [myself.gui.x, myself.gui.y, myself.gui.z])
         _call_operation_ignoring_to_many_arguments(operation, [cle_input, output, x, y, z])
         max_intensity = cle.maximum_of_all_pixels(output)
         if max_intensity == 0:
@@ -132,16 +150,16 @@ def filter(input1: Image, operation_name: str = cle.gamma_correction.__name__, x
         output = cle.pull(output)
 
         # show result in napari
-        if not hasattr(filter.self, 'layer'):
-            filter.self.viewer.add_image(output, colormap=input1.colormap, translate=input1.translate)
+        if not hasattr(myself, 'layer'):
+            myself.viewer.add_image(output, colormap=input1.colormap, translate=input1.translate)
         else:
-            filter.self.layer.data = output
-            filter.self.layer.name = "Result of " + operation.__name__
-            filter.self.layer.contrast_limits=(0, max_intensity)
-            filter.self.layer.translate = input1.translate
+            myself.layer.data = output
+            myself.layer.name = "Result of " + operation.__name__
+            myself.layer.contrast_limits=(0, max_intensity)
+            myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
-@magicgui(
+@magic_factory(
     auto_call=True,
     layout='vertical',
     input1={'label':'Image'},
@@ -150,35 +168,35 @@ def filter(input1: Image, operation_name: str = cle.gamma_correction.__name__, x
     radius_y=plus_minus_1k,
     radius_z=plus_minus_1k
 )
-def binarize(input1: Layer, operation_name : str = cle.threshold_otsu.__name__, radius_x : int = 1, radius_y : int = 1, radius_z : int = 0):
+def binarize(input1: Layer, operation_name : str = cle.threshold_otsu.__name__, radius_x : int = 1, radius_y : int = 1, radius_z : int = 0, myself = None):
     if input1 is not None:
         # execute operation
         cle_input1 = cle.push(input1.data)
         output = cle.create_like(cle_input1)
         operation = cle.operation(operation_name)
         # update GUI
-        label_parameters(operation, [binarize.radius_x, binarize.radius_y, binarize.radius_z])
+        label_parameters(operation, [myself.gui.radius_x, myself.gui.radius_y, myself.gui.radius_z])
         _call_operation_ignoring_to_many_arguments(operation, [cle_input1, output, radius_x, radius_y, radius_z])
         output = cle.pull(output).astype(int)
 
         # show result in napari
-        if not hasattr(binarize.self, 'layer'):
-            binarize.self.viewer.add_labels(output, translate=input1.translate)
+        if not hasattr(myself, 'layer'):
+            myself.viewer.add_labels(output, translate=input1.translate)
         else:
-            binarize.self.layer.data = output
-            binarize.self.layer.contrast_limits = (0, 1)
-            binarize.self.layer.name = "Result of " + operation.__name__
-            binarize.self.layer.translate = input1.translate
+            myself.layer.data = output
+            myself.layer.contrast_limits = (0, 1)
+            myself.layer.name = "Result of " + operation.__name__
+            myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
-@magicgui(
+@magic_factory(
     auto_call=True,
     layout='vertical',
     input1={'label':'Image 1'},
     input2={'label':'Image 2'},
     operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['combine', 'in assistant'], must_not_have_categories=['map']).keys()}
 )
-def combine(input1: Layer, input2: Layer = None, operation_name: str = cle.binary_and.__name__):
+def combine(input1: Layer, input2: Layer = None, operation_name: str = cle.binary_and.__name__, myself = None):
     if input1 is not None:
         if (input2 is None):
             input2 = input1
@@ -195,16 +213,16 @@ def combine(input1: Layer, input2: Layer = None, operation_name: str = cle.binar
         output = cle.pull(output)
 
         # show result in napari
-        if not hasattr(combine.self, 'layer'):
-            combine.self.viewer.add_image(output, colormap=input1.colormap, translate=input1.translate)
+        if not hasattr(myself, 'layer'):
+            myself.viewer.add_image(output, colormap=input1.colormap, translate=input1.translate)
         else:
-            combine.self.layer.data = output
-            combine.self.layer.name = "Result of " + operation.__name__
-            combine.self.layer.contrast_limits=(0, max_intensity)
-            combine.self.layer.translate = input1.translate
+            myself.layer.data = output
+            myself.layer.name = "Result of " + operation.__name__
+            myself.layer.contrast_limits=(0, max_intensity)
+            myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
-@magicgui(
+@magic_factory(
     auto_call=True,
     layout='vertical',
     input1={'label':'Image'},
@@ -212,27 +230,27 @@ def combine(input1: Layer, input2: Layer = None, operation_name: str = cle.binar
     a=plus_minus_1k,
     b=plus_minus_1k
 )
-def label(input1: Layer, operation_name: str = cle.connected_components_labeling_box.__name__, a : float = 2, b : float = 2):
+def label(input1: Layer, operation_name: str = cle.connected_components_labeling_box.__name__, a : float = 2, b : float = 2, myself = None):
     if input1 is not None:
         # execute operation
         cle_input1 = cle.push(input1.data)
         operation = cle.operation(operation_name)
         # update GUI
-        label_parameters(operation, [label.a, label.b])
+        label_parameters(operation, [myself.gui.a, myself.gui.b])
         output = cle.create_like(cle_input1)
         _call_operation_ignoring_to_many_arguments(operation, [cle_input1, output, a, b])
         output = cle.pull(output).astype(int)
 
         # show result in napari
-        if not hasattr(label.self, 'layer'):
-            label.self.viewer.add_labels(output, translate=input1.translate)
+        if not hasattr(myself, 'layer'):
+            myself.viewer.add_labels(output, translate=input1.translate)
         else:
-            label.self.layer.data = output
-            label.self.layer.name = "Result of " + operation.__name__
-            label.self.layer.translate = input1.translate
+            myself.layer.data = output
+            myself.layer.name = "Result of " + operation.__name__
+            myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
-@magicgui(
+@magic_factory(
     auto_call=True,
     layout='vertical',
     input1={'label':'Labels'},
@@ -240,34 +258,34 @@ def label(input1: Layer, operation_name: str = cle.connected_components_labeling
     min = plus_minus_1k,
     max = plus_minus_1k
 )
-def label_processing(input1: Labels, operation_name: str = cle.exclude_labels_on_edges.__name__, min: float=0, max:float=100):
+def label_processing(input1: Labels, operation_name: str = cle.exclude_labels_on_edges.__name__, min: float=0, max:float=100, myself = None):
     if input1 is not None:
         # execute operation
         cle_input1 = cle.push(input1.data)
         output = cle.create_like(cle_input1)
         operation = cle.operation(operation_name)
         # update GUI
-        label_parameters(operation, [label_processing.min, label_processing.max])
+        label_parameters(operation, [myself.gui.min, myself.gui.max])
         _call_operation_ignoring_to_many_arguments(operation, [cle_input1, output, min, max])
         output = cle.pull(output).astype(int)
 
         # show result in napari
-        if not hasattr(label_processing.self, 'layer'):
-            label_processing.self.viewer.add_labels(output, translate=input1.translate)
+        if not hasattr(myself, 'layer'):
+            myself.viewer.add_labels(output, translate=input1.translate)
         else:
-            label_processing.self.layer.data = output
-            label_processing.self.layer.name = "Result of " + operation.__name__
-            label_processing.self.layer.translate = input1.translate
+            myself.layer.data = output
+            myself.layer.name = "Result of " + operation.__name__
+            myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
-@magicgui(
+@magic_factory(
     auto_call=True,
     layout='vertical',
     input1={'label':'Image'},
     input2={'label':'Labels'},
     operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['combine', 'map', 'in assistant']).keys()}
 )
-def label_measurements(input1: Image, input2: Labels = None, operation_name: str = cle.label_mean_intensity_map.__name__, n : float = 1):
+def label_measurements(input1: Image, input2: Labels = None, operation_name: str = cle.label_mean_intensity_map.__name__, n : float = 1, myself = None):
     if input1 is not None:
         if (input2 is None):
             input2 = input1
@@ -278,7 +296,7 @@ def label_measurements(input1: Image, input2: Labels = None, operation_name: str
         output = cle.create_like(cle_input1)
         operation = cle.operation(operation_name)
         # update GUI
-        label_parameters(operation, [label_measurements.n])
+        label_parameters(operation, [myself.gui.n])
         _call_operation_ignoring_to_many_arguments(operation, [cle_input1, cle_input2, output, n])
         max_intensity = cle.maximum_of_all_pixels(output)
         if max_intensity == 0:
@@ -286,31 +304,31 @@ def label_measurements(input1: Image, input2: Labels = None, operation_name: str
         output = cle.pull(output)
 
         # show result in napari
-        if not hasattr(label_measurements.self, 'layer'):
-            label_measurements.self.viewer.add_image(output, colormap='turbo', interpolation='nearest', translate=input1.translate)
+        if not hasattr(myself, 'layer'):
+            myself.viewer.add_image(output, colormap='turbo', interpolation='nearest', translate=input1.translate)
         else:
-            label_measurements.self.layer.data = output
-            label_measurements.self.layer.name = "Result of " + operation.__name__
-            label_measurements.self.layer.contrast_limits=(0, max_intensity)
-            label_measurements.self.layer.translate = input1.translate
+            myself.layer.data = output
+            myself.layer.name = "Result of " + operation.__name__
+            myself.layer.contrast_limits=(0, max_intensity)
+            myself.layer.translate = input1.translate
 
 
 # -----------------------------------------------------------------------------
-@magicgui(
+@magic_factory(
     auto_call=True,
     layout='vertical',
     input1={'label': 'Labels'},
     operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['label measurement', 'mesh', 'in assistant'], must_not_have_categories=["combine"]).keys()},
     n = {'min': 0, 'max': 1000}
 )
-def mesh(input1: Labels, operation_name : str = cle.draw_mesh_between_touching_labels.__name__, n : float = 1):
+def mesh(input1: Labels, operation_name : str = cle.draw_mesh_between_touching_labels.__name__, n : float = 1, myself = None):
     if input1 is not None:
         # execute operation
         cle_input1 = cle.push(input1.data)
         output = cle.create_like(cle_input1)
         operation = cle.operation(operation_name)
         # update GUI
-        label_parameters(operation, [mesh.n])
+        label_parameters(operation, [myself.gui.n])
         _call_operation_ignoring_to_many_arguments(operation, [cle_input1, output, n])
         min_intensity = cle.minimum_of_all_pixels(output)
         max_intensity = cle.maximum_of_all_pixels(output)
@@ -319,30 +337,30 @@ def mesh(input1: Labels, operation_name : str = cle.draw_mesh_between_touching_l
         output = cle.pull(output)
 
         # show result in napari
-        if not hasattr(mesh.self, 'layer'):
-            mesh.self.viewer.add_image(output, colormap='green', blending='additive', translate=input1.translate)
+        if not hasattr(myself, 'layer'):
+            myself.viewer.add_image(output, colormap='green', blending='additive', translate=input1.translate)
         else:
-            mesh.self.layer.data = output
-            mesh.self.layer.name = "Result of " + operation.__name__
-            mesh.self.layer.contrast_limits=(min_intensity, max_intensity)
-            mesh.self.layer.translate = input1.translate
+            myself.layer.data = output
+            myself.layer.name = "Result of " + operation.__name__
+            myself.layer.contrast_limits=(min_intensity, max_intensity)
+            myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
-@magicgui(
+@magic_factory(
     auto_call=True,
     layout='vertical',
     input1={'label':'Labels'},
     operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['label measurement', 'map', 'in assistant'], must_not_have_categories=["combine"]).keys()},
     n = {'min': 0, 'max': 1000}
 )
-def map(input1: Labels, operation_name: str = cle.label_pixel_count_map.__name__, n : float = 1):
+def map(input1: Labels, operation_name: str = cle.label_pixel_count_map.__name__, n : float = 1, myself = None):
     if input1 is not None:
         # execute operation
         cle_input1 = cle.push(input1.data)
         output = cle.create_like(cle_input1)
         operation = cle.operation(operation_name)
         # update GUI
-        label_parameters(operation, [map.n])
+        label_parameters(operation, [myself.gui.n])
         _call_operation_ignoring_to_many_arguments(operation, [cle_input1, output, n])
         max_intensity = cle.maximum_of_all_pixels(output)
         if max_intensity == 0:
@@ -350,23 +368,23 @@ def map(input1: Labels, operation_name: str = cle.label_pixel_count_map.__name__
         output = cle.pull(output)
 
         # show result in napari
-        if not hasattr(map.self, 'layer'):
-            map.self.viewer.add_image(output, colormap='turbo', interpolation='nearest', translate=input1.translate)
+        if not hasattr(myself, 'layer'):
+            myself.viewer.add_image(output, colormap='turbo', interpolation='nearest', translate=input1.translate)
         else:
-            map.self.layer.data = output
-            map.self.layer.name = "Result of " + operation.__name__
-            map.self.layer.contrast_limits=(0, max_intensity)
-            map.self.layer.translate = input1.translate
+            myself.layer.data = output
+            myself.layer.name = "Result of " + operation.__name__
+            myself.layer.contrast_limits=(0, max_intensity)
+            myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
 # A special case of ooperation is measurement: it results in a table instead of
 # an image
-@magicgui(
+@magic_factory(
     layout='vertical',
     input1={'label': 'Image'},
     labels={'label': 'Labels'},
     call_button="Measure")
-def measure(input1: Image = None, labels : Labels = None):
+def measure(input1: Image = None, labels : Labels = None, myself = None):
     if input1 is not None and labels is not None:
         from skimage.measure import regionprops_table
         table = regionprops_table(labels.data.astype(int), intensity_image=input1.data, properties=('area', 'centroid', 'mean_intensity'))
@@ -382,7 +400,7 @@ def table_to_widget(table : dict) -> QTableWidget:
     return view
 
 # -----------------------------------------------------------------------------
-@magicgui(
+@magic_factory(
     auto_call=True,
     layout='vertical',
     input1={'label':'Image'},
@@ -391,7 +409,7 @@ def table_to_widget(table : dict) -> QTableWidget:
     b=plus_minus_1k,
     c=plus_minus_1k
 )
-def transform(input1: Layer, operation_name : str = cle.sub_stack.__name__, a : float = 0, b : float = 0, c : float = 0, d : bool = False, e : bool = False):
+def transform(input1: Layer, operation_name : str = cle.sub_stack.__name__, a : float = 0, b : float = 0, c : float = 0, d : bool = False, e : bool = False, myself = None):
     if input1 is not None:
         # determine shift; todo: to this in a generic way
         import numpy as np
@@ -406,30 +424,30 @@ def transform(input1: Layer, operation_name : str = cle.sub_stack.__name__, a : 
         output = None
         operation = cle.operation(operation_name)
         # update GUI
-        label_parameters(operation, [transform.a, transform.b, transform.c, transform.d, transform.e])
+        label_parameters(operation, [myself.gui.a, myself.gui.b, myself.gui.c, myself.gui.d, myself.gui.e])
         output = _call_operation_ignoring_to_many_arguments(operation, [cle_input1, output, a, b, c, d, e])
         output = cle.pull(output).astype(int)
 
         # show result in napari
-        if not hasattr(transform.self, 'layer'):
+        if not hasattr(myself, 'layer'):
             if isinstance(input1, Labels):
-                transform.self.viewer.add_labels(output, translate=translate)
+                myself.viewer.add_labels(output, translate=translate)
             else:
-                transform.self.viewer.add_image(output, translate=translate)
+                myself.viewer.add_image(output, translate=translate)
         else:
-            transform.self.layer.data = output
-            transform.self.layer.contrast_limits = input1.contrast_limits
-            transform.self.layer.name = "Result of " + operation.__name__
-            transform.self.layer.translate = translate
+            myself.layer.data = output
+            myself.layer.contrast_limits = input1.contrast_limits
+            myself.layer.name = "Result of " + operation.__name__
+            myself.layer.translate = translate
 
 # -----------------------------------------------------------------------------
-@magicgui(
+@magic_factory(
     auto_call=True,
     layout='vertical',
     input1={'label':'Image'},
     operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['projection', 'in assistant']).keys()}
 )
-def projection(input1: Layer, operation_name : str = cle.maximum_z_projection.__name__):
+def projection(input1: Layer, operation_name : str = cle.maximum_z_projection.__name__, myself = None):
     if input1 is not None:
         # execute operation
         cle_input1 = cle.push(input1.data)
@@ -440,13 +458,13 @@ def projection(input1: Layer, operation_name : str = cle.maximum_z_projection.__
 
 
         # show result in napari
-        if not hasattr(projection.self, 'layer'):
+        if not hasattr(myself, 'layer'):
             if isinstance(input1, Labels):
-                projection.self.viewer.add_labels(output, translate=input1.translate[1:3])
+                myself.viewer.add_labels(output, translate=input1.translate[1:3])
             else:
-                projection.self.viewer.add_image(output, translate=input1.translate[1:3])
+                myself.viewer.add_image(output, translate=input1.translate[1:3])
         else:
-            projection.self.layer.data = output
-            projection.self.layer.contrast_limits = input1.contrast_limits
-            projection.self.layer.name = "Result of " + operation.__name__
-            projection.self.layer.translate = input1.translate[1:3]
+            myself.layer.data = output
+            myself.layer.contrast_limits = input1.contrast_limits
+            myself.layer.name = "Result of " + operation.__name__
+            myself.layer.translate = input1.translate[1:3]

--- a/napari_pyclesperanto_assistant/_operations/_operations.py
+++ b/napari_pyclesperanto_assistant/_operations/_operations.py
@@ -37,11 +37,11 @@ def label_parameters(operation, parameters):
     for parameter in sig.parameters:
         if sig.parameters[parameter].annotation in [int, str, float, bool]:
             if len(parameters) > count:
-                parameters[count].label = parameter
+                parameters[count]._label = parameter
                 parameters[count].text = parameter
                 count = count + 1
     for i in range(count, len(parameters)):
-        parameters[i].label = ""
+        parameters[i]._label = ""
         parameters[i].text = ""
 
 class StatefulFunction():
@@ -68,15 +68,17 @@ class StatefulFunctionFactory():
     def get(self):
         return StatefulFunction(self.factory)
 
-@magic_factory(auto_call=True,
-                layout='vertical',
-                input1={'label':'Image'},
-                operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['filter', 'denoise','in assistant'], must_not_have_categories=['combine']).keys()},
-                x=plus_minus_1k,
-                y=plus_minus_1k,
-                z=plus_minus_1k)
-def denoise(input1: Image, operation_name: str = cle.gaussian_blur.__name__, x: float = 1, y: float = 1,
-            z: float = 0, myself=None):
+def magic_denoise():
+    return magicgui(_denoise, auto_call=True,
+                    layout='vertical',
+                    input1={'label':'Image'},
+                    operation_name={'label': 'Operation', 'choices':list(cle.operations(must_have_categories=['filter', 'denoise','in assistant'], must_not_have_categories=['combine']).keys())},
+                    x=plus_minus_1k,
+                    y=plus_minus_1k,
+                    z=plus_minus_1k)
+
+def _denoise(input1: Image, operation_name: str = cle.gaussian_blur.__name__, x: float = 1, y: float = 1,
+             z: float = 0, myself=None):
     if input1:
         # execute operation
         cle_input = cle.push(input1.data)
@@ -100,25 +102,24 @@ def denoise(input1: Image, operation_name: str = cle.gaussian_blur.__name__, x: 
             myself.layer.translate = input1.translate
 
 
+def magic_background_removal():
+    return magicgui(_background_removal,
+                    auto_call=True,
+                    layout='vertical',
+                    input1={'label':'Image'},
+                    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['filter', 'background removal','in assistant'], must_not_have_categories=['combine']).keys()},
+                    x=plus_minus_1k,
+                    y=plus_minus_1k,
+                    z=plus_minus_1k)
 
-
-@magic_factory(
-    auto_call=True,
-    layout='vertical',
-    input1={'label':'Image'},
-    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['filter', 'background removal','in assistant'], must_not_have_categories=['combine']).keys()},
-    x=plus_minus_1k,
-    y=plus_minus_1k,
-    z=plus_minus_1k,
-)
-def background_removal(input1: Image, operation_name: str = cle.top_hat_box.__name__, x: float = 10, y: float = 10, z: float = 0, myself = None):
+def _background_removal(input1: Image, operation_name: str = cle.top_hat_box.__name__, x: float = 10, y: float = 10, z: float = 0, myself = None):
     if input1:
         # execute operation
         cle_input = cle.push(input1.data)
         output = cle.create_like(cle_input)
         operation = cle.operation(operation_name)
         # update GUI
-        label_parameters(operation, [myself.gui.x, background_removal.y, background_removal.z])
+        label_parameters(operation, [myself.gui.x, myself.gui.y, myself.gui.z])
         _call_operation_ignoring_to_many_arguments(operation, [cle_input, output, x, y, z])
         max_intensity = cle.maximum_of_all_pixels(output)
         if max_intensity == 0:
@@ -134,16 +135,17 @@ def background_removal(input1: Image, operation_name: str = cle.top_hat_box.__na
             myself.layer.contrast_limits=(0, max_intensity)
             myself.layer.translate = input1.translate
 
-@magic_factory(
-    auto_call=True,
-    layout='vertical',
-    input1={'label':'Image'},
-    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['filter', 'in assistant'], must_not_have_categories=['combine', 'denoise', 'background removal']).keys()},
-    x=plus_minus_1k,
-    y=plus_minus_1k,
-    z=plus_minus_1k,
-)
-def filter(input1: Image, operation_name: str = cle.gamma_correction.__name__, x: float = 1, y: float = 1, z: float = 0, myself = None):
+def magic_filter():
+    return magicgui(_filter,
+                    auto_call=True,
+                    layout='vertical',
+                    input1={'label':'Image'},
+                    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['filter', 'in assistant'], must_not_have_categories=['combine', 'denoise', 'background removal']).keys()},
+                    x=plus_minus_1k,
+                    y=plus_minus_1k,
+                    z=plus_minus_1k)
+
+def _filter(input1: Image, operation_name: str = cle.gamma_correction.__name__, x: float = 1, y: float = 1, z: float = 0, myself = None):
     if input1:
         # execute operation
         cle_input = cle.push(input1.data)
@@ -167,16 +169,18 @@ def filter(input1: Image, operation_name: str = cle.gamma_correction.__name__, x
             myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
-@magic_factory(
-    auto_call=True,
-    layout='vertical',
-    input1={'label':'Image'},
-    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['binarize', 'in assistant'], must_not_have_categories=['combine']).keys()},
-    radius_x=plus_minus_1k,
-    radius_y=plus_minus_1k,
-    radius_z=plus_minus_1k
-)
-def binarize(input1: Layer, operation_name : str = cle.threshold_otsu.__name__, radius_x : int = 1, radius_y : int = 1, radius_z : int = 0, myself = None):
+
+def magic_binarize():
+    return magicgui(_binarize,
+                    auto_call=True,
+                    layout='vertical',
+                    input1={'label':'Image'},
+                    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['binarize', 'in assistant'], must_not_have_categories=['combine']).keys()},
+                    radius_x=plus_minus_1k,
+                    radius_y=plus_minus_1k,
+                    radius_z=plus_minus_1k)
+
+def _binarize(input1: Layer, operation_name : str = cle.threshold_otsu.__name__, radius_x : int = 1, radius_y : int = 1, radius_z : int = 0, myself = None):
     if input1 is not None:
         # execute operation
         cle_input1 = cle.push(input1.data)
@@ -197,14 +201,16 @@ def binarize(input1: Layer, operation_name : str = cle.threshold_otsu.__name__, 
             myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
-@magic_factory(
-    auto_call=True,
-    layout='vertical',
-    input1={'label':'Image 1'},
-    input2={'label':'Image 2'},
-    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['combine', 'in assistant'], must_not_have_categories=['map']).keys()}
-)
-def combine(input1: Layer, input2: Layer = None, operation_name: str = cle.binary_and.__name__, myself = None):
+
+def magic_combine():
+    return magicgui(_combine,
+                    auto_call=True,
+                    layout='vertical',
+                    input1={'label':'Image 1'},
+                    input2={'label':'Image 2'},
+                    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['combine', 'in assistant'], must_not_have_categories=['map']).keys()})
+
+def _combine(input1: Layer, input2: Layer = None, operation_name: str = cle.binary_and.__name__, myself = None):
     if input1 is not None:
         if (input2 is None):
             input2 = input1
@@ -230,15 +236,17 @@ def combine(input1: Layer, input2: Layer = None, operation_name: str = cle.binar
             myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
-@magic_factory(
-    auto_call=True,
-    layout='vertical',
-    input1={'label':'Image'},
-    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['label', 'in assistant']).keys()},
-    a=plus_minus_1k,
-    b=plus_minus_1k
-)
-def label(input1: Layer, operation_name: str = cle.connected_components_labeling_box.__name__, a : float = 2, b : float = 2, myself = None):
+
+def magic_label():
+    return magicgui(_label,
+                    auto_call=True,
+                    layout='vertical',
+                    input1={'label':'Image'},
+                    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['label', 'in assistant']).keys()},
+                    a=plus_minus_1k,
+                    b=plus_minus_1k)
+
+def _label(input1: Layer, operation_name: str = cle.connected_components_labeling_box.__name__, a : float = 2, b : float = 2, myself = None):
     if input1 is not None:
         # execute operation
         cle_input1 = cle.push(input1.data)
@@ -258,15 +266,17 @@ def label(input1: Layer, operation_name: str = cle.connected_components_labeling
             myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
-@magic_factory(
-    auto_call=True,
-    layout='vertical',
-    input1={'label':'Labels'},
-    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['label processing', 'in assistant']).keys()},
-    min = plus_minus_1k,
-    max = plus_minus_1k
-)
-def label_processing(input1: Labels, operation_name: str = cle.exclude_labels_on_edges.__name__, min: float=0, max:float=100, myself = None):
+
+def magic_label_processing():
+    return magicgui(_label_processing,
+                    auto_call=True,
+                    layout='vertical',
+                    input1={'label':'Labels'},
+                    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['label processing', 'in assistant']).keys()},
+                    min = plus_minus_1k,
+                    max = plus_minus_1k)
+
+def _label_processing(input1: Labels, operation_name: str = cle.exclude_labels_on_edges.__name__, min: float=0, max:float=100, myself = None):
     if input1 is not None:
         # execute operation
         cle_input1 = cle.push(input1.data)
@@ -286,14 +296,16 @@ def label_processing(input1: Labels, operation_name: str = cle.exclude_labels_on
             myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
-@magic_factory(
-    auto_call=True,
-    layout='vertical',
-    input1={'label':'Image'},
-    input2={'label':'Labels'},
-    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['combine', 'map', 'in assistant']).keys()}
-)
-def label_measurements(input1: Image, input2: Labels = None, operation_name: str = cle.label_mean_intensity_map.__name__, n : float = 1, myself = None):
+
+def magic_label_measurements():
+    return magicgui(_label_measurements,
+                    auto_call=True,
+                    layout='vertical',
+                    input1={'label':'Image'},
+                    input2={'label':'Labels'},
+                    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['combine', 'map', 'in assistant']).keys()})
+
+def _label_measurements(input1: Image, input2: Labels = None, operation_name: str = cle.label_mean_intensity_map.__name__, n : float = 1, myself = None):
     if input1 is not None:
         if (input2 is None):
             input2 = input1
@@ -322,14 +334,16 @@ def label_measurements(input1: Image, input2: Labels = None, operation_name: str
 
 
 # -----------------------------------------------------------------------------
-@magic_factory(
-    auto_call=True,
-    layout='vertical',
-    input1={'label': 'Labels'},
-    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['label measurement', 'mesh', 'in assistant'], must_not_have_categories=["combine"]).keys()},
-    n = {'min': 0, 'max': 1000}
-)
-def mesh(input1: Labels, operation_name : str = cle.draw_mesh_between_touching_labels.__name__, n : float = 1, myself = None):
+
+def magic_mesh():
+    return magicgui(_mesh,
+        auto_call=True,
+        layout='vertical',
+        input1={'label': 'Labels'},
+        operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['label measurement', 'mesh', 'in assistant'], must_not_have_categories=["combine"]).keys()},
+        n = {'min': 0, 'max': 1000})
+
+def _mesh(input1: Labels, operation_name : str = cle.draw_mesh_between_touching_labels.__name__, n : float = 1, myself = None):
     if input1 is not None:
         # execute operation
         cle_input1 = cle.push(input1.data)
@@ -354,14 +368,16 @@ def mesh(input1: Labels, operation_name : str = cle.draw_mesh_between_touching_l
             myself.layer.translate = input1.translate
 
 # -----------------------------------------------------------------------------
-@magic_factory(
-    auto_call=True,
-    layout='vertical',
-    input1={'label':'Labels'},
-    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['label measurement', 'map', 'in assistant'], must_not_have_categories=["combine"]).keys()},
-    n = {'min': 0, 'max': 1000}
-)
-def map(input1: Labels, operation_name: str = cle.label_pixel_count_map.__name__, n : float = 1, myself = None):
+
+def magic_map():
+    return magicgui(_map,
+        auto_call=True,
+        layout='vertical',
+        input1={'label':'Labels'},
+        operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['label measurement', 'map', 'in assistant'], must_not_have_categories=["combine"]).keys()},
+        n = {'min': 0, 'max': 1000})
+
+def _map(input1: Labels, operation_name: str = cle.label_pixel_count_map.__name__, n : float = 1, myself = None):
     if input1 is not None:
         # execute operation
         cle_input1 = cle.push(input1.data)
@@ -387,12 +403,14 @@ def map(input1: Labels, operation_name: str = cle.label_pixel_count_map.__name__
 # -----------------------------------------------------------------------------
 # A special case of ooperation is measurement: it results in a table instead of
 # an image
-@magic_factory(
-    layout='vertical',
-    input1={'label': 'Image'},
-    labels={'label': 'Labels'},
-    call_button="Measure")
-def measure(input1: Image = None, labels : Labels = None, myself = None):
+
+def magic_measure():
+    return magicgui(_measure,
+                    layout='vertical',
+                    input1={'label': 'Image'},
+                    labels={'label': 'Labels'},
+                    call_button="Measure")
+def _measure(input1: Image = None, labels : Labels = None, myself = None):
     if input1 is not None and labels is not None:
         from skimage.measure import regionprops_table
         table = regionprops_table(labels.data.astype(int), intensity_image=input1.data, properties=('area', 'centroid', 'mean_intensity'))
@@ -408,16 +426,18 @@ def table_to_widget(table : dict) -> QTableWidget:
     return view
 
 # -----------------------------------------------------------------------------
-@magic_factory(
-    auto_call=True,
-    layout='vertical',
-    input1={'label':'Image'},
-    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['transform', 'in assistant']).keys()},
-    a=plus_minus_1k,
-    b=plus_minus_1k,
-    c=plus_minus_1k
-)
-def transform(input1: Layer, operation_name : str = cle.sub_stack.__name__, a : float = 0, b : float = 0, c : float = 0, d : bool = False, e : bool = False, myself = None):
+
+def magic_transform():
+    return magicgui(_transform,
+                    auto_call=True,
+                    layout='vertical',
+                    input1={'label':'Image'},
+                    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['transform', 'in assistant']).keys()},
+                    a=plus_minus_1k,
+                    b=plus_minus_1k,
+                    c=plus_minus_1k)
+
+def _transform(input1: Layer, operation_name : str = cle.sub_stack.__name__, a : float = 0, b : float = 0, c : float = 0, d : bool = False, e : bool = False, myself = None):
     if input1 is not None:
         # determine shift; todo: to this in a generic way
         import numpy as np
@@ -449,13 +469,15 @@ def transform(input1: Layer, operation_name : str = cle.sub_stack.__name__, a : 
             myself.layer.translate = translate
 
 # -----------------------------------------------------------------------------
-@magic_factory(
-    auto_call=True,
-    layout='vertical',
-    input1={'label':'Image'},
-    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['projection', 'in assistant']).keys()}
-)
-def projection(input1: Layer, operation_name : str = cle.maximum_z_projection.__name__, myself = None):
+
+def magic_projection():
+    return magicgui(_projection,
+                    auto_call=True,
+                    layout='vertical',
+                    input1={'label':'Image'},
+                    operation_name={'label': 'Operation', 'choices':cle.operations(must_have_categories=['projection', 'in assistant']).keys()})
+
+def _projection(input1: Layer, operation_name : str = cle.maximum_z_projection.__name__, myself = None):
     if input1 is not None:
         # execute operation
         cle_input1 = cle.push(input1.data)

--- a/napari_pyclesperanto_assistant/_operations/_operations.py
+++ b/napari_pyclesperanto_assistant/_operations/_operations.py
@@ -59,7 +59,7 @@ class SelfAwareFunctionInstance():
 
 class SelfAwareFunctionFactory():
     """
-    This factory allows to specify a megic-factory annotated function. Whenever `get()` is called, a new instance
+    This factory allows to specify a magic-factory annotated function. Whenever `get()` is called, a new instance
     is created so that these functions can independently store parameters.
     """
     def __init__(self, factory):

--- a/napari_pyclesperanto_assistant/_operations/_operations.py
+++ b/napari_pyclesperanto_assistant/_operations/_operations.py
@@ -45,15 +45,23 @@ def label_parameters(operation, parameters):
         parameters[i].text = ""
 
 class SelfAwareFunctionInstance():
+    """
+    Objects of this class serve as container for the below magic-factory annotated functions. These functions should
+    have a 'myself' parameter where they can store anything and where they have access to the viewer and the layer
+    they belong to.
+    """
     def __init__(self, factory):
         self.gui = factory()
         self.gui.myself.bind(self)
 
-
     def get(self):
         return self.gui
 
-class SelfAwareFunction():
+class SelfAwareFunctionFactory():
+    """
+    This factory allows to specify a megic-factory annotated function. Whenever `get()` is called, a new instance
+    is created so that these functions can independently store parameters.
+    """
     def __init__(self, factory):
         self.factory = factory
 

--- a/napari_pyclesperanto_assistant/_operations/_operations.py
+++ b/napari_pyclesperanto_assistant/_operations/_operations.py
@@ -44,7 +44,7 @@ def label_parameters(operation, parameters):
         parameters[i].label = ""
         parameters[i].text = ""
 
-class SelfAwareFunctionInstance():
+class StatefulFunction():
     """
     Objects of this class serve as container for the below magic-factory annotated functions. These functions should
     have a 'myself' parameter where they can store anything and where they have access to the viewer and the layer
@@ -57,7 +57,7 @@ class SelfAwareFunctionInstance():
     def get(self):
         return self.gui
 
-class SelfAwareFunctionFactory():
+class StatefulFunctionFactory():
     """
     This factory allows to specify a magic-factory annotated function. Whenever `get()` is called, a new instance
     is created so that these functions can independently store parameters.
@@ -66,7 +66,7 @@ class SelfAwareFunctionFactory():
         self.factory = factory
 
     def get(self):
-        return SelfAwareFunctionInstance(self.factory)
+        return StatefulFunction(self.factory)
 
 @magic_factory(auto_call=True,
                 layout='vertical',

--- a/napari_pyclesperanto_assistant/_tests/test_dock_widget.py
+++ b/napari_pyclesperanto_assistant/_tests/test_dock_widget.py
@@ -2,8 +2,10 @@ import warnings
 
 from pathlib import Path
 import napari_pyclesperanto_assistant
-from .._operations._operations import StatefulFunctionFactory, denoise, background_removal, filter, binarize, combine, label, \
-    label_processing, map, mesh, measure, label_measurements, transform, projection
+from .._operations._operations import StatefulFunctionFactory, magic_denoise, magic_background_removal, \
+    magic_filter, magic_binarize, magic_combine, magic_label, \
+    magic_label_processing, magic_map, magic_mesh, magic_measure, magic_label_measurements, \
+    magic_transform, magic_projection
 
 # workaround for leaking Widgets
 def _init_test():
@@ -42,20 +44,20 @@ def test_complex_workflow(make_napari_viewer):
     filename = str(root / 'data' / 'Lund_000500_resampled-cropped.tif')
     layer = viewer.open(filename)
 
-    assistant_gui._activate(StatefulFunctionFactory(denoise))
-    #assistant_gui._activate(StatefulFunctionFactory(background_removal))
-    #assistant_gui._activate(StatefulFunctionFactory(filter))
-    #assistant_gui._activate(StatefulFunctionFactory(binarize))
-    #assistant_gui._activate(StatefulFunctionFactory(label))
-    #assistant_gui._activate(StatefulFunctionFactory(label_processing))
-    #assistant_gui._activate(StatefulFunctionFactory(map))
-    #assistant_gui._activate(StatefulFunctionFactory(combine))
+    assistant_gui._activate(StatefulFunctionFactory(magic_denoise))
+    assistant_gui._activate(StatefulFunctionFactory(magic_background_removal))
+    assistant_gui._activate(StatefulFunctionFactory(magic_filter))
+    assistant_gui._activate(StatefulFunctionFactory(magic_binarize))
+    assistant_gui._activate(StatefulFunctionFactory(magic_label))
+    assistant_gui._activate(StatefulFunctionFactory(magic_label_processing))
+    assistant_gui._activate(StatefulFunctionFactory(magic_map))
+    assistant_gui._activate(StatefulFunctionFactory(magic_combine))
 
-    #assistant_gui._activate(StatefulFunctionFactory(transform))
-    #assistant_gui._activate(StatefulFunctionFactory(projection))
+    assistant_gui._activate(StatefulFunctionFactory(magic_transform))
+    assistant_gui._activate(StatefulFunctionFactory(magic_projection))
 
     #assistant_gui._export_jython_code_to_clipboard()
-    #assistant_gui._export_notebook(filename="test.ipynb")
+    assistant_gui._export_notebook(filename="test.ipynb")
 
     _finalize_test(initial, viewer)
 

--- a/napari_pyclesperanto_assistant/_tests/test_dock_widget.py
+++ b/napari_pyclesperanto_assistant/_tests/test_dock_widget.py
@@ -2,7 +2,7 @@ import warnings
 
 from pathlib import Path
 import napari_pyclesperanto_assistant
-from .._operations._operations import SelfAwareFunctionFactory, denoise, background_removal, filter, binarize, combine, label, \
+from .._operations._operations import StatefulFunctionFactory, denoise, background_removal, filter, binarize, combine, label, \
     label_processing, map, mesh, measure, label_measurements, transform, projection
 
 # workaround for leaking Widgets
@@ -42,17 +42,17 @@ def test_complex_workflow(make_napari_viewer):
     filename = str(root / 'data' / 'Lund_000500_resampled-cropped.tif')
     layer = viewer.open(filename)
 
-    assistant_gui._activate(SelfAwareFunctionFactory(denoise))
-    assistant_gui._activate(SelfAwareFunctionFactory(background_removal))
-    assistant_gui._activate(SelfAwareFunctionFactory(filter))
-    assistant_gui._activate(SelfAwareFunctionFactory(binarize))
-    assistant_gui._activate(SelfAwareFunctionFactory(label))
-    assistant_gui._activate(SelfAwareFunctionFactory(label_processing))
-    assistant_gui._activate(SelfAwareFunctionFactory(map))
-    assistant_gui._activate(SelfAwareFunctionFactory(combine))
+    assistant_gui._activate(StatefulFunctionFactory(denoise))
+    assistant_gui._activate(StatefulFunctionFactory(background_removal))
+    assistant_gui._activate(StatefulFunctionFactory(filter))
+    assistant_gui._activate(StatefulFunctionFactory(binarize))
+    assistant_gui._activate(StatefulFunctionFactory(label))
+    assistant_gui._activate(StatefulFunctionFactory(label_processing))
+    assistant_gui._activate(StatefulFunctionFactory(map))
+    assistant_gui._activate(StatefulFunctionFactory(combine))
 
-    assistant_gui._activate(SelfAwareFunctionFactory(transform))
-    assistant_gui._activate(SelfAwareFunctionFactory(projection))
+    assistant_gui._activate(StatefulFunctionFactory(transform))
+    assistant_gui._activate(StatefulFunctionFactory(projection))
 
     #assistant_gui._export_jython_code_to_clipboard()
     assistant_gui._export_notebook(filename="test.ipynb")

--- a/napari_pyclesperanto_assistant/_tests/test_dock_widget.py
+++ b/napari_pyclesperanto_assistant/_tests/test_dock_widget.py
@@ -43,19 +43,19 @@ def test_complex_workflow(make_napari_viewer):
     layer = viewer.open(filename)
 
     assistant_gui._activate(StatefulFunctionFactory(denoise))
-    assistant_gui._activate(StatefulFunctionFactory(background_removal))
-    assistant_gui._activate(StatefulFunctionFactory(filter))
-    assistant_gui._activate(StatefulFunctionFactory(binarize))
-    assistant_gui._activate(StatefulFunctionFactory(label))
-    assistant_gui._activate(StatefulFunctionFactory(label_processing))
-    assistant_gui._activate(StatefulFunctionFactory(map))
-    assistant_gui._activate(StatefulFunctionFactory(combine))
+    #assistant_gui._activate(StatefulFunctionFactory(background_removal))
+    #assistant_gui._activate(StatefulFunctionFactory(filter))
+    #assistant_gui._activate(StatefulFunctionFactory(binarize))
+    #assistant_gui._activate(StatefulFunctionFactory(label))
+    #assistant_gui._activate(StatefulFunctionFactory(label_processing))
+    #assistant_gui._activate(StatefulFunctionFactory(map))
+    #assistant_gui._activate(StatefulFunctionFactory(combine))
 
-    assistant_gui._activate(StatefulFunctionFactory(transform))
-    assistant_gui._activate(StatefulFunctionFactory(projection))
+    #assistant_gui._activate(StatefulFunctionFactory(transform))
+    #assistant_gui._activate(StatefulFunctionFactory(projection))
 
     #assistant_gui._export_jython_code_to_clipboard()
-    assistant_gui._export_notebook(filename="test.ipynb")
+    #assistant_gui._export_notebook(filename="test.ipynb")
 
     _finalize_test(initial, viewer)
 

--- a/napari_pyclesperanto_assistant/_tests/test_dock_widget.py
+++ b/napari_pyclesperanto_assistant/_tests/test_dock_widget.py
@@ -2,7 +2,7 @@ import warnings
 
 from pathlib import Path
 import napari_pyclesperanto_assistant
-from .._operations._operations import SelfAwareFunction, denoise, background_removal, filter, binarize, combine, label, \
+from .._operations._operations import SelfAwareFunctionFactory, denoise, background_removal, filter, binarize, combine, label, \
     label_processing, map, mesh, measure, label_measurements, transform, projection
 
 # workaround for leaking Widgets
@@ -42,17 +42,17 @@ def test_complex_workflow(make_napari_viewer):
     filename = str(root / 'data' / 'Lund_000500_resampled-cropped.tif')
     layer = viewer.open(filename)
 
-    assistant_gui._activate(SelfAwareFunction(denoise))
-    assistant_gui._activate(SelfAwareFunction(background_removal))
-    assistant_gui._activate(SelfAwareFunction(filter))
-    assistant_gui._activate(SelfAwareFunction(binarize))
-    assistant_gui._activate(SelfAwareFunction(label))
-    assistant_gui._activate(SelfAwareFunction(label_processing))
-    assistant_gui._activate(SelfAwareFunction(map))
-    assistant_gui._activate(SelfAwareFunction(combine))
+    assistant_gui._activate(SelfAwareFunctionFactory(denoise))
+    assistant_gui._activate(SelfAwareFunctionFactory(background_removal))
+    assistant_gui._activate(SelfAwareFunctionFactory(filter))
+    assistant_gui._activate(SelfAwareFunctionFactory(binarize))
+    assistant_gui._activate(SelfAwareFunctionFactory(label))
+    assistant_gui._activate(SelfAwareFunctionFactory(label_processing))
+    assistant_gui._activate(SelfAwareFunctionFactory(map))
+    assistant_gui._activate(SelfAwareFunctionFactory(combine))
 
-    assistant_gui._activate(SelfAwareFunction(transform))
-    assistant_gui._activate(SelfAwareFunction(projection))
+    assistant_gui._activate(SelfAwareFunctionFactory(transform))
+    assistant_gui._activate(SelfAwareFunctionFactory(projection))
 
     #assistant_gui._export_jython_code_to_clipboard()
     assistant_gui._export_notebook(filename="test.ipynb")

--- a/napari_pyclesperanto_assistant/_tests/test_dock_widget.py
+++ b/napari_pyclesperanto_assistant/_tests/test_dock_widget.py
@@ -2,7 +2,7 @@ import warnings
 
 from pathlib import Path
 import napari_pyclesperanto_assistant
-from .._operations._operations import denoise, background_removal, filter, binarize, combine, label, \
+from .._operations._operations import SelfAwareFunction, denoise, background_removal, filter, binarize, combine, label, \
     label_processing, map, mesh, measure, label_measurements, transform, projection
 
 # workaround for leaking Widgets
@@ -12,6 +12,9 @@ def _init_test():
 
 def _finalize_test(initial, viewer):
     from qtpy.QtWidgets import QApplication
+
+    viewer.close()
+
     QApplication.processEvents()
     leaks = set(QApplication.topLevelWidgets()).difference(initial)
 
@@ -39,22 +42,17 @@ def test_complex_workflow(make_napari_viewer):
     filename = str(root / 'data' / 'Lund_000500_resampled-cropped.tif')
     layer = viewer.open(filename)
 
-    assistant_gui._activate(denoise)
-    assistant_gui._activate(background_removal)
-    assistant_gui._activate(filter)
-    assistant_gui._activate(binarize)
-    assistant_gui._activate(label)
-    assistant_gui._activate(label_processing)
-    assistant_gui._activate(map)
-    assistant_gui._activate(combine)
+    assistant_gui._activate(SelfAwareFunction(denoise))
+    assistant_gui._activate(SelfAwareFunction(background_removal))
+    assistant_gui._activate(SelfAwareFunction(filter))
+    assistant_gui._activate(SelfAwareFunction(binarize))
+    assistant_gui._activate(SelfAwareFunction(label))
+    assistant_gui._activate(SelfAwareFunction(label_processing))
+    assistant_gui._activate(SelfAwareFunction(map))
+    assistant_gui._activate(SelfAwareFunction(combine))
 
-    #assistant_gui._activate(label)
-    #assistant_gui._activate(mesh)
-    #assistant_gui._activate(measure)
-    #assistant_gui._activate(label_measurements)
-
-    assistant_gui._activate(transform)
-    assistant_gui._activate(projection)
+    assistant_gui._activate(SelfAwareFunction(transform))
+    assistant_gui._activate(SelfAwareFunction(projection))
 
     #assistant_gui._export_jython_code_to_clipboard()
     assistant_gui._export_notebook(filename="test.ipynb")


### PR DESCRIPTION
Here, I introduced stateful functions. Thus, a magic-factory annotated operation can access a parameter `myself` that is binded after creating the magicgui. 

Todo:
- [ ] widgets still leaking
- [x] After starting a magicgui the second time, operations cannot be chosen anymore

1st start:
![image](https://user-images.githubusercontent.com/12660498/114284426-21cbd600-9a50-11eb-89ab-a3a2b148f3af.png)

2nd start:
![image](https://user-images.githubusercontent.com/12660498/114284434-39a35a00-9a50-11eb-9a73-3f7213f930de.png)
