### PR TITLE
hand over the OCL array to napari instead of converting

### DIFF
--- a/napari_pyclesperanto_assistant/_gui/_category_widget.py
+++ b/napari_pyclesperanto_assistant/_gui/_category_widget.py
@@ -105,9 +105,11 @@ def _show_result(
     if clims[1] == 0:
         clims[1] = 1
 
-    data = cle.pull(gpu_out)
     if layer_type == "labels":
-        data = data.astype(int)
+        data = cle.pull(gpu_out).astype(int)
+    else:
+        data = gpu_out
+
     try:
         # look for an existing layer
         layer = next(x for x in viewer.layers if x.metadata.get(OP_ID) == op_id)


### PR DESCRIPTION
In case of image layers we can pass the OCLArray to napari after [this](https://github.com/clEsperanto/pyclesperanto_prototype/pull/104/) related PR is merged. Label-layers don't work yet because these have to be of type `int` and all OCLArrays are `float` at the moment.

This will spare about a second per gigabyte when post-processing a given layer, because we don't have to push the data again to GPU memory. It stays there :-)