### PR TITLE
Fix jython generator

### DIFF
--- a/napari_pyclesperanto_assistant/_gui/_Assistant.py
+++ b/napari_pyclesperanto_assistant/_gui/_Assistant.py
@@ -15,8 +15,7 @@ from ._category_widget import (
     OP_NAME_PARAM,
     VIEWER_PARAM,
     make_gui_for_category,
-    num_positional_args,
-    OUTPUT_PLACEHOLDER,
+    num_positional_args
 )
 
 if TYPE_CHECKING:
@@ -153,26 +152,26 @@ class Assistant(QWidget):
                 key = "some_random_key"
 
             args = []
+            inputs = []
             for w in mgui:
                 if w.name in (VIEWER_PARAM, OP_NAME_PARAM):
-                    args.append(OUTPUT_PLACEHOLDER)
                     continue
                 if "napari.layers" in type(w.value).__module__:
                     op_id = w.value.metadata.get(OP_ID)
                     if op_id is None:
                         op_id = "some_random_key"
-                        graph[self._id_to_name(op_id, name_dict)] = (cle.imread, "w.value._source")  # TODO
-                    args.append(self._id_to_name(op_id, name_dict))
+                        graph[self._id_to_name(op_id, name_dict)] = (cle.imread, ["w.value._source"], [])  # TODO
+                    inputs.append(self._id_to_name(op_id, name_dict))
                 else:
                     args.append(w.value)
             op = getattr(cle, getattr(mgui, OP_NAME_PARAM).value)
 
             # shorten args by eliminating not-used ones
             if op:
-                nargs = num_positional_args(op)
+                nargs = num_positional_args(op) - 1 - len(inputs)
                 args = args[:nargs]
 
-            graph[self._id_to_name(key, name_dict)] = (op, *args)
+            graph[self._id_to_name(key, name_dict)] = (op, inputs, args)
 
         return graph
 

--- a/napari_pyclesperanto_assistant/_gui/_Assistant.py
+++ b/napari_pyclesperanto_assistant/_gui/_Assistant.py
@@ -10,8 +10,14 @@ from qtpy.QtWidgets import QFileDialog, QHBoxLayout, QPushButton, QVBoxLayout, Q
 from .._categories import CATEGORIES, Category
 from .._pipeline import Pipeline
 from ._button_grid import ButtonGrid
-from ._category_widget import OP_ID, OP_NAME_PARAM, VIEWER_PARAM, make_gui_for_category, num_positional_args, \
-    OUTPUT_PLACEHOLDER
+from ._category_widget import (
+    OP_ID,
+    OP_NAME_PARAM,
+    VIEWER_PARAM,
+    make_gui_for_category,
+    num_positional_args,
+    OUTPUT_PLACEHOLDER,
+)
 
 if TYPE_CHECKING:
     from magicgui.widgets import FunctionGui

--- a/napari_pyclesperanto_assistant/_gui/_Assistant.py
+++ b/napari_pyclesperanto_assistant/_gui/_Assistant.py
@@ -168,11 +168,6 @@ class Assistant(QWidget):
 
             graph[self._id_to_name(key, name_dict)] = (op, *args)
 
-        for k in name_dict:
-            print(k, ":", name_dict.get(k))
-
-        print(graph)
-
         return graph
 
     def to_jython(self, filename=None):

--- a/napari_pyclesperanto_assistant/_gui/_Assistant.py
+++ b/napari_pyclesperanto_assistant/_gui/_Assistant.py
@@ -10,8 +10,8 @@ from qtpy.QtWidgets import QFileDialog, QHBoxLayout, QPushButton, QVBoxLayout, Q
 from .._categories import CATEGORIES, Category
 from .._pipeline import Pipeline
 from ._button_grid import ButtonGrid
-from ._category_widget import OP_ID, OP_NAME_PARAM, VIEWER_PARAM, make_gui_for_category
-
+from ._category_widget import OP_ID, OP_NAME_PARAM, VIEWER_PARAM, make_gui_for_category, num_positional_args, \
+    OUTPUT_PLACEHOLDER
 
 if TYPE_CHECKING:
     from magicgui.widgets import FunctionGui
@@ -145,10 +145,11 @@ class Assistant(QWidget):
             key = layer.metadata.get(OP_ID)
             if not key:
                 key = "some_random_key"
-                
+
             args = []
             for w in mgui:
                 if w.name in (VIEWER_PARAM, OP_NAME_PARAM):
+                    args.append(OUTPUT_PLACEHOLDER)
                     continue
                 if "napari.layers" in type(w.value).__module__:
                     op_id = w.value.metadata.get(OP_ID)
@@ -159,7 +160,12 @@ class Assistant(QWidget):
                 else:
                     args.append(w.value)
             op = getattr(cle, getattr(mgui, OP_NAME_PARAM).value)
-            # todo: shorten args array here
+
+            # shorten args by eliminating not-used ones
+            if op:
+                nargs = num_positional_args(op)
+                args = args[:nargs]
+
             graph[self._id_to_name(key, name_dict)] = (op, *args)
 
         for k in name_dict:

--- a/napari_pyclesperanto_assistant/_gui/_category_widget.py
+++ b/napari_pyclesperanto_assistant/_gui/_category_widget.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 VIEWER_PARAM = "viewer"
 OP_NAME_PARAM = "op_name"
 OP_ID = "op_id"
+OUTPUT_PLACEHOLDER = "output_placeholder"
 
 
 def num_positional_args(func, types=[cle.Image, int, str, float, bool]) -> int:

--- a/napari_pyclesperanto_assistant/_gui/_category_widget.py
+++ b/napari_pyclesperanto_assistant/_gui/_category_widget.py
@@ -17,8 +17,6 @@ if TYPE_CHECKING:
 VIEWER_PARAM = "viewer"
 OP_NAME_PARAM = "op_name"
 OP_ID = "op_id"
-OUTPUT_PLACEHOLDER = "output_placeholder"
-
 
 def num_positional_args(func, types=[cle.Image, int, str, float, bool]) -> int:
     params = signature(func).parameters

--- a/napari_pyclesperanto_assistant/_pipeline.py
+++ b/napari_pyclesperanto_assistant/_pipeline.py
@@ -79,7 +79,6 @@ class NotebookGenerator:
 class Step:
     operation: str
     args: Sequence[Any] = field(default_factory=tuple)  # kwargs might be better
-    inputs: Sequence[str] = field(default_factory=list)
     output: str = "image"
     is_labels: bool = False
     clims: Optional[Tuple[float, float]] = None
@@ -151,9 +150,7 @@ class Pipeline:
         steps = []
         for key in graph.keys(): # Robert observed that this didn't work: dask.order.order(graph):
             op, *args = graph[key]
-            inputs = []
-
-            steps.append(Step(operation=op.__name__, inputs=inputs, args=args, output=key))
+            steps.append(Step(operation=op.__name__, args=args, output=key))
         return cls(steps=steps)
 
 

--- a/napari_pyclesperanto_assistant/_pipeline.py
+++ b/napari_pyclesperanto_assistant/_pipeline.py
@@ -37,14 +37,9 @@ class JythonGenerator:
 
     @staticmethod
     def operate(step, n) -> str:
-        args = step.args # list(map(repr, step.args))
-        # if len(step.inputs) > 0:
-        # args = step.inputs + [f"cle.create_like({step.inputs[0]})"] + args
-        if args:
-            from napari_pyclesperanto_assistant._gui._category_widget import OUTPUT_PLACEHOLDER
-            args = [f"cle.create_like({step.args[0]})" if x == OUTPUT_PLACEHOLDER else x for x in args]
-
-        print("ARGS: ", args)
+        args = step.args
+        from napari_pyclesperanto_assistant._gui._category_widget import OUTPUT_PLACEHOLDER
+        args = [f"cle.create_like({step.args[0]})" if x == OUTPUT_PLACEHOLDER else x for x in args]
 
         return f"{step.output} = cle.{step.operation}({', '.join(map(str, args))})"
 
@@ -56,7 +51,6 @@ class JythonGenerator:
             show_args.extend(map(str, step.clims))
         return f"cle.imshow({', '.join(show_args)})"
 
-# collect notebook cells
 from nbformat.v4 import new_code_cell
 from nbformat.v4 import new_markdown_cell
 class NotebookGenerator:
@@ -103,7 +97,6 @@ class Pipeline:
             yield vistor.operate(step, n)
             if self.show:
                 yield vistor.show(step, n)
-            #yield ""  # newline
 
     def to_jython(self, filename=None):
         code = "\n".join(self._generate(JythonGenerator))

--- a/napari_pyclesperanto_assistant/_pipeline.py
+++ b/napari_pyclesperanto_assistant/_pipeline.py
@@ -34,18 +34,18 @@ class JythonGenerator:
         return "import pyclesperanto_prototype as cle"
 
     @staticmethod
-    def subheader(step, n):
+    def subheader(step):
         # jupytext will render "# ##" as an h2 header in ipynb
         return f"# ## {step.operation.replace('_', ' ')}"
 
     @staticmethod
-    def operate(step, n) -> str:
+    def operate(step) -> str:
         # TODO: in case of imread, we may do something special here...
         args = step.inputs + [f"cle.create_like({step.inputs[0]})"] + step.args
         return f"{step.output} = cle.{step.operation}({', '.join(map(str, args))})"
 
     @staticmethod
-    def show(step, n):
+    def show(step):
         title = f"Result of {step.operation.replace('_', ' ')}"
         show_args = [f"image{n}", repr(title), str(step.is_labels)]
         if step.clims:
@@ -76,12 +76,12 @@ class Pipeline:
         yield vistor.imports()
         yield vistor.newline()
         yield vistor.newline()
-        for n, step in enumerate(self.steps):
-            yield vistor.subheader(step, n)
+        for step in self.steps:
+            yield vistor.subheader(step)
             yield vistor.newline()
-            yield vistor.operate(step, n)
+            yield vistor.operate(step)
             if self.show:
-                yield vistor.show(step, n)
+                yield vistor.show(step)
             yield vistor.newline()
 
     def to_jython(self, filename=None):

--- a/napari_pyclesperanto_assistant/_pipeline.py
+++ b/napari_pyclesperanto_assistant/_pipeline.py
@@ -148,7 +148,7 @@ class Pipeline:
     def from_dask(cls, graph):
         import dask
         steps = []
-        for key in graph.keys(): # Robert observed that this didn't work: dask.order.order(graph):
+        for key in dask.order.order(graph):
             op, *args = graph[key]
             steps.append(Step(operation=op.__name__, args=args, output=key))
         return cls(steps=steps)


### PR DESCRIPTION
Hey @tlambert03 

this fixes the Jython generator by
* The variable names such as 'image1` are now the keys for the operations in the graph-dictionary and in the associated args lists. Thus, operations with multiple input images are supported.
* `dask.order.order` resulted in a wrong order. I commented it out
* I crop off the parameters that magicgui may know about, but which aren't actually accepted by a given function

Let me know what you think!

Cheers,
Robert