### PR TITLE
workaround for saving GPU-backed layers

### DIFF
--- a/napari_pyclesperanto_assistant/_convert_to_numpy.py
+++ b/napari_pyclesperanto_assistant/_convert_to_numpy.py
@@ -1,0 +1,12 @@
+import numpy as np
+from magicgui import magicgui
+from napari.types import ImageData, LabelsData, LayerDataTuple
+from typing_extensions import Annotated
+from napari.layers import Image, Labels, Layer
+LayerInput = Annotated[Layer, {"label": "Image"}]
+
+def convert_to_numpy(layer : LayerInput) -> Layer:
+    if isinstance(layer, Labels):
+        return Labels(np.asarray(layer.data))
+    else:
+        return Image(np.asarray(layer.data))

--- a/napari_pyclesperanto_assistant/_napari_plugin.py
+++ b/napari_pyclesperanto_assistant/_napari_plugin.py
@@ -9,6 +9,7 @@ from ._categories import CATEGORIES
 from ._gui import Assistant
 from ._gui._category_widget import make_gui_for_category
 from ._statistics_of_labeled_pixels import statistics_of_labeled_pixels
+from ._convert_to_numpy import convert_to_numpy
 from ._categories import attach_tooltips
 
 @napari_hook_implementation
@@ -32,4 +33,4 @@ def napari_provide_sample_data():
 
 @napari_hook_implementation
 def napari_experimental_provide_function():
-    return [statistics_of_labeled_pixels]
+    return [statistics_of_labeled_pixels, convert_to_numpy]


### PR DESCRIPTION
This is a temporary workaround for https://github.com/napari/napari/issues/2926

It allows users to save GPU-backed layers to disc by manually converting them to numpy-arrays before saving...