### PR TITLE
adds BSD-3-Clause identifier to package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     author="Robert Haase, Talley Lambert",
     author_email="robert.haase@tu-dresden.de",
     description="OpenCL based GPU-accelerated image processing in napari",
+    license="BSD-3-Clause",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/clesperanto/napari_pyclesperanto_assistant",


### PR DESCRIPTION
the LICENSE in the repo cannot be inferred by Github (probably b/c of long author list? idk)

this PR adds the SPDX identifier to the Python package, enabling the license to be listed at https://www.napari-hub.org/plugins/napari-pyclesperanto-assistant