### PR TITLE
use remove_dock_widget instead of dirty hack

### DIFF
--- a/napari_pyclesperanto_assistant/_gui/_category_widget.py
+++ b/napari_pyclesperanto_assistant/_gui/_category_widget.py
@@ -262,7 +262,7 @@ def make_gui_for_category(category: Category) -> magicgui.widgets.FunctionGui[La
                 layer = event.value
                 if layer in inputs or layer is result_layer:
                     try:
-                        viewer.window.remove_dock_widget(widget)
+                        viewer.window.remove_dock_widget(widget.native)
                     except:
                         pass
 


### PR DESCRIPTION
This would avoid accessing a private member in the napari viewer. However, it will only work after a change to napari was done...