### PR TITLE
Fix conda install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ It is recommended to install the assistant using conda. If you have never used c
 [this blog post](https://biapol.github.io/blog/johannes_mueller/anaconda_getting_started/) first. 
 
 ```shell
-conda create --name cle_39 python==3.9 napari-pyclesperanto-assistant
+conda create --name cle_39 python=3.9 napari-pyclesperanto-assistant
 conda activate cle_39
 ```
 


### PR DESCRIPTION
Conda uses a single `=` to set package versions:
https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-pkgs.html
The existing instructions using `python==3.9` resolve to python to version 3.9.0, rather than the proper python 3.9 version, so installs can fail due to version incompatibility
Fixes https://github.com/clEsperanto/napari_pyclesperanto_assistant/issues/63